### PR TITLE
Improve file path handling

### DIFF
--- a/PhotoLocator/AutoTagViewModel.cs
+++ b/PhotoLocator/AutoTagViewModel.cs
@@ -141,6 +141,10 @@ namespace PhotoLocator
         {
             if (string.IsNullOrEmpty(TraceFilePath))
                 return GpsTraces;
+
+            // Support Windows Copy Full Path string to be used by the user, Example: "C:\temp\file.jpeg"
+            if (TraceFilePath.Contains("\"")) TraceFilePath = TraceFilePath.Replace("\"", "");
+
             var minDistance = TimeSpan.FromMinutes(MaxTimestampDifference);
             Directory.SetCurrentDirectory(Path.GetDirectoryName(_selectedItems.First().FullPath)!);
             if (File.Exists(TraceFilePath))

--- a/PhotoLocator/AutoTagViewModel.cs
+++ b/PhotoLocator/AutoTagViewModel.cs
@@ -139,7 +139,7 @@ namespace PhotoLocator
         
         private IEnumerable<GpsTrace> LoadAdditionalGpsTraces()
         {
-            if (string.IsNullOrEmpty(TraceFilePath))
+            if (string.IsNullOrWhiteSpace(TraceFilePath))
                 return GpsTraces;
 
             // Support Windows Copy Full Path string to be used by the user, Example: "C:\temp\file.jpeg"

--- a/PhotoLocator/MainViewModel.cs
+++ b/PhotoLocator/MainViewModel.cs
@@ -665,7 +665,7 @@ namespace PhotoLocator
             if (allSelected.Length == 0)
                 return;
             var destination = Interaction.InputBox($"Copy {allSelected.Length} selected item(s).\n\nDestination:", "Copy files", (PhotoFolderPath ?? string.Empty).Trim('\\'));
-            if (string.IsNullOrEmpty(destination) || destination == PhotoFolderPath || destination == ".")
+            if (string.IsNullOrWhiteSpace(destination) || destination == PhotoFolderPath || destination == ".")
                 return;
             await RunProcessWithProgressBarAsync((progressCallback, ct) => Task.Run(() =>
             {
@@ -699,7 +699,7 @@ namespace PhotoLocator
                 return;
             focusedItem = GetNearestUnchecked(focusedItem, allSelected);
             var destination = Interaction.InputBox($"Move {allSelected.Length} selected item(s).\n\nDestination:", "Move files", (PhotoFolderPath ?? string.Empty).Trim('\\'));
-            if (string.IsNullOrEmpty(destination) || destination == PhotoFolderPath || destination == ".")
+            if (string.IsNullOrWhiteSpace(destination) || destination == PhotoFolderPath || destination == ".")
                 return;
             SelectedItem = null;
             await RunProcessWithProgressBarAsync((progressCallback, ct) => Task.Run(() =>
@@ -729,10 +729,10 @@ namespace PhotoLocator
 
         public ICommand CreateFolderCommand => new RelayCommand(o =>
         {
-            if (string.IsNullOrEmpty(PhotoFolderPath))
+            if (string.IsNullOrWhiteSpace(PhotoFolderPath))
                 return;
             var folderName = Interaction.InputBox("Folder name:", "Create folder");
-            if (string.IsNullOrEmpty(folderName))
+            if (string.IsNullOrWhiteSpace(folderName))
                 return;
             Directory.CreateDirectory(Path.Combine(PhotoFolderPath, folderName));
         });
@@ -751,7 +751,7 @@ namespace PhotoLocator
         {
             if (SelectedItem is not null)
                 Process.Start(new ProcessStartInfo("explorer.exe", $"/select, \"{SelectedItem.FullPath}\"") { UseShellExecute = true });
-            else if (!string.IsNullOrEmpty(PhotoFolderPath))
+            else if (!string.IsNullOrWhiteSpace(PhotoFolderPath))
                 Process.Start(new ProcessStartInfo("explorer.exe", PhotoFolderPath) { UseShellExecute = true });
         });
 
@@ -869,7 +869,7 @@ namespace PhotoLocator
             DisposeFileSystemWatcher();
             var selectedName = SelectedItem?.Name;
             CancelPictureLoading();
-            if (string.IsNullOrEmpty(PhotoFolderPath))
+            if (string.IsNullOrWhiteSpace(PhotoFolderPath))
                 return;
             Items.Clear();
             Polylines.Clear();

--- a/PhotoLocator/MainWindow.xaml.cs
+++ b/PhotoLocator/MainWindow.xaml.cs
@@ -90,13 +90,13 @@ namespace PhotoLocator
 
         private void CheckToolPaths()
         {
-            if (string.IsNullOrEmpty(_viewModel.Settings.ExifToolPath))
+            if (string.IsNullOrWhiteSpace(_viewModel.Settings.ExifToolPath))
             {
                 var exifToolPath = Path.Combine(Path.GetDirectoryName(GetType().Assembly.Location)!, "exiftool");
                 if (Directory.Exists(exifToolPath))
                     _viewModel.Settings.ExifToolPath = Directory.EnumerateFiles(exifToolPath, "*.exe").FirstOrDefault();
             }
-            if (string.IsNullOrEmpty(_viewModel.Settings.FFmpegPath))
+            if (string.IsNullOrWhiteSpace(_viewModel.Settings.FFmpegPath))
             {
                 var ffmpegPath = Path.Combine(Path.GetDirectoryName(GetType().Assembly.Location)!, "ffmpeg", "ffmpeg.exe");
                 if (File.Exists(ffmpegPath))
@@ -117,7 +117,7 @@ namespace PhotoLocator
         {
             using var registrySettings = new RegistrySettings();
             registrySettings.AssignSettings(_viewModel.Settings);
-            if (!string.IsNullOrEmpty(_viewModel.PhotoFolderPath))
+            if (!string.IsNullOrWhiteSpace(_viewModel.PhotoFolderPath))
                 registrySettings.PhotoFolderPath = _viewModel.PhotoFolderPath;
             registrySettings.ViewMode = _viewModel.SelectedViewModeItem?.Tag as ViewMode? ?? ViewMode.Map;
             registrySettings.LeftColumnWidth = (int)LeftColumn.Width.Value;

--- a/PhotoLocator/SelectDropActionWindow.xaml.cs
+++ b/PhotoLocator/SelectDropActionWindow.xaml.cs
@@ -47,7 +47,7 @@ namespace PhotoLocator
 
         public bool IsIncludeAvailable => DroppedEntries.Any(f => _mainViewModel.Items.All(i => i.FullPath != f));
 
-        public bool IsCopyAndMoveAvailable => !string.IsNullOrEmpty(CurrentPath) && Path.GetDirectoryName(DroppedEntries[0]) != CurrentPath;
+        public bool IsCopyAndMoveAvailable => !string.IsNullOrWhiteSpace(CurrentPath) && Path.GetDirectoryName(DroppedEntries[0]) != CurrentPath;
 
         public bool IsProgressBarVisible
         {

--- a/PhotoLocator/Settings/SettingsWindow.xaml.cs
+++ b/PhotoLocator/Settings/SettingsWindow.xaml.cs
@@ -21,14 +21,14 @@ namespace PhotoLocator.Settings
         {
             OkButton.Focus();
 
-            if (!string.IsNullOrEmpty(Settings.SavedFilePostfix))
+            if (!string.IsNullOrWhiteSpace(Settings.SavedFilePostfix))
             { 
                 foreach(var ch in Path.GetInvalidFileNameChars())
                     if (Settings.SavedFilePostfix.Contains(ch, StringComparison.Ordinal))
                         throw new UserMessageException($"Postfix contains invalid character '{ch}'");
             }
 
-            if (!string.IsNullOrEmpty(Settings.ExifToolPath))
+            if (!string.IsNullOrWhiteSpace(Settings.ExifToolPath))
             {
                 const string ExifToolName = "exiftool.exe";
 
@@ -43,7 +43,7 @@ namespace PhotoLocator.Settings
                 else if (Settings.ExifToolPath.EndsWith("(-k).exe", StringComparison.OrdinalIgnoreCase))
                     throw new UserMessageException($"Invalid ExifTool executable name (-k means pause before exiting)");
             }
-            if (!string.IsNullOrEmpty(Settings.FFmpegPath))
+            if (!string.IsNullOrWhiteSpace(Settings.FFmpegPath))
             {
                 const string FFmpegToolName = "ffmpeg.exe";
 

--- a/PhotoLocatorTest/Helpers/VideoTransformsTest.cs
+++ b/PhotoLocatorTest/Helpers/VideoTransformsTest.cs
@@ -14,7 +14,7 @@ namespace PhotoLocator.Helpers
         [TestMethod]
         public async Task RunFFmpegWithStreamOutputImagesAsync_ShouldProcessImages()
         {
-            if (string.IsNullOrEmpty(FFmpegPath))
+            if (string.IsNullOrWhiteSpace(FFmpegPath))
                 Assert.Inconclusive("FFmpegPath not set");
             var settings = new ObservableSettings() { FFmpegPath = FFmpegPath };
             var videoTransforms = new VideoTransforms(settings);
@@ -33,7 +33,7 @@ namespace PhotoLocator.Helpers
         [TestMethod]
         public async Task RunFFmpegWithStreamInputImagesAsync_ShouldEncodeImages()
         {
-            if (string.IsNullOrEmpty(FFmpegPath))
+            if (string.IsNullOrWhiteSpace(FFmpegPath))
                 Assert.Inconclusive("FFmpegPath not set");
             var settings = new ObservableSettings() { FFmpegPath = FFmpegPath };
             var videoTransforms = new VideoTransforms(settings);
@@ -54,7 +54,7 @@ namespace PhotoLocator.Helpers
         [TestMethod]
         public async Task RunFFmpegWithStreamInputImagesAsync_ShouldProcessImages()
         {
-            if (string.IsNullOrEmpty(FFmpegPath))
+            if (string.IsNullOrWhiteSpace(FFmpegPath))
                 Assert.Inconclusive("FFmpegPath not set");
             var settings = new ObservableSettings() { FFmpegPath = FFmpegPath };
             var videoTransforms = new VideoTransforms(settings);


### PR DESCRIPTION
Lets start with something simple for the first PR.

The trace file input box allows for copy/paste of a file path. I always use the Windows feature "Copy Full Path" which copies the path as `"C:\path\file.end"`. However this is not fully supported everywhere - hence the quotation marks have to be handled. With Windows 11 the "Copy Full Path" feature is now visible to the regular user (not using Shift-Click) so I think we should support it (and it saves me time during testing).

In addition I added a check whether the provided file path is a directory or file. Just because `File.Exists()` returns false it does not indicate a directory. I also replaced all occurences (I hope) of basic path checks from `IsNullOrEmpty()` to `IsNullOrWhiteSpace()`. I encountered most people are not aware of this handy method and I like to check for white spaces in paths as well.