### PR TITLE
Implement workaround to handle possible invalid gotoextr coordinates

### DIFF
--- a/PhotoLocator/Extensions/StringExtension.cs
+++ b/PhotoLocator/Extensions/StringExtension.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace PhotoLocator.Extensions;
+
+public static class StringExtension
+{
+    /// <summary>
+    /// Resolve invalid number format ".-123" which should be "-0.123". Occurs i.e. with gotoextr in the region of London.
+    /// </summary>
+    /// <param name="floatText">Text to be checked for invalid negative number definition</param>
+    /// <returns>Input text cleaned of invalid format e.g. ".-123" -> "-0.123"</returns>
+    public static string ResolveInvalidNumberFormat(this string floatText)
+    {
+        if (floatText.StartsWith(".-", StringComparison.InvariantCultureIgnoreCase))
+            floatText = floatText.Replace(".-", "-0.", StringComparison.InvariantCultureIgnoreCase);
+
+        return floatText;
+    }
+}

--- a/PhotoLocator/Gps/GpxDecoder.cs
+++ b/PhotoLocator/Gps/GpxDecoder.cs
@@ -1,4 +1,5 @@
 ﻿using MapControl;
+using PhotoLocator.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -29,9 +30,12 @@ namespace PhotoLocator.Gps
                         var time = trkpt["time"];
                         if (lat != null && lon != null && time != null)
                         {
+                            var latitudeString = lat.InnerText.ResolveInvalidNumberFormat();
+                            var longitudeString = lon.InnerText.ResolveInvalidNumberFormat();
+
                             trace.Locations.Add(new Location(
-                                double.Parse(lat.InnerText, CultureInfo.InvariantCulture),
-                                double.Parse(lon.InnerText, CultureInfo.InvariantCulture)));
+                                double.Parse(latitudeString, CultureInfo.InvariantCulture),
+                                double.Parse(longitudeString, CultureInfo.InvariantCulture)));
                             trace.TimeStamps.Add(DateTime.Parse(time.InnerText, CultureInfo.InvariantCulture));
                         }
                     }

--- a/PhotoLocator/Gps/KmlDecoder.cs
+++ b/PhotoLocator/Gps/KmlDecoder.cs
@@ -1,4 +1,5 @@
 ﻿using MapControl;
+using PhotoLocator.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -44,9 +45,12 @@ namespace PhotoLocator.Gps
                         else if (child.Name == "gx:coord")
                         {
                             var coords = child.InnerText.Split(' ');
+                            var latitudeString = coords[1].ResolveInvalidNumberFormat();
+                            var longitudeString = coords[0].ResolveInvalidNumberFormat();
+
                             placemark.Coordinates.Add(new Location(
-                                double.Parse(coords[1], CultureInfo.InvariantCulture),
-                                double.Parse(coords[0], CultureInfo.InvariantCulture)));
+                                double.Parse(latitudeString, CultureInfo.InvariantCulture),
+                                double.Parse(longitudeString, CultureInfo.InvariantCulture)));
                             if (placemark.StartTime != default)
                             {
                                 placemarks.Add(placemark);
@@ -69,9 +73,12 @@ namespace PhotoLocator.Gps
                     foreach (var coord in coordsNode.InnerText.Split(' ', StringSplitOptions.RemoveEmptyEntries))
                     {
                         var coords = coord.Split(',');
+                        var latitudeString = coords[1].ResolveInvalidNumberFormat();
+                        var longitudeString = coords[0].ResolveInvalidNumberFormat();
+
                         placemark.Coordinates.Add(new Location(
-                            double.Parse(coords[1], CultureInfo.InvariantCulture),
-                            double.Parse(coords[0], CultureInfo.InvariantCulture)));
+                            double.Parse(latitudeString, CultureInfo.InvariantCulture),
+                            double.Parse(longitudeString, CultureInfo.InvariantCulture)));
                     }
                     placemarks.Add(placemark);
                 }


### PR DESCRIPTION
This PR handles invalid coordinates provided by *gotoextr*. With some hope the developer can find time to fix the issue on his side. However I like the tool so much that I want to add it to the *PhotoLocator* documentation. As such I am proposing to add this workaround to improve the applications resilience.

It may occur that a negative longitude (e.g. in London) is not represented as `-.123` but as `.-123`. This crashes the *PhotoLocator* import / data extraction. I propose we add this workaround in the meantime.