### PR TITLE
Support for reading Google timeline export files

### DIFF
--- a/PhotoLocator/AutoTagViewModel.cs
+++ b/PhotoLocator/AutoTagViewModel.cs
@@ -155,9 +155,8 @@ namespace PhotoLocator
             Directory.SetCurrentDirectory(Path.GetDirectoryName(_selectedItems.First().FullPath)!);
             if (File.Exists(TraceFilePath))
                 return GpsTraces.Concat(GpsTrace.DecodeGpsTraceFile(TraceFilePath, minDistance));
-            return GpsTraces.
-                Concat(Directory.EnumerateFiles(TraceFilePath, "*.gpx").SelectMany(fileName => GpsTrace.DecodeGpsTraceFile(fileName, minDistance))).
-                Concat(Directory.EnumerateFiles(TraceFilePath, "*.kml").SelectMany(fileName => GpsTrace.DecodeGpsTraceFile(fileName, minDistance)));
+            return GpsTraces.Concat(GpsTrace.TraceExtensions.SelectMany(
+                format => Directory.EnumerateFiles(TraceFilePath, "*" + format).SelectMany(fileName => GpsTrace.DecodeGpsTraceFile(fileName, minDistance))));
         }
 
         private void SaveSettings()

--- a/PhotoLocator/Gps/GpsTrace.cs
+++ b/PhotoLocator/Gps/GpsTrace.cs
@@ -2,6 +2,7 @@
 using PhotoLocator.MapDisplay;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 
@@ -9,9 +10,11 @@ namespace PhotoLocator.Gps
 {
     public class GpsTrace : PolylineItem
     {
+        public static readonly HashSet<string> TraceExtensions = [".gpx", ".kml", ".json"];
+
         public string? Name { get; set; }
         
-        public List<DateTime> TimeStamps { get; } = [];
+        public Collection<DateTime> TimeStamps { get; } = [];
 
         public Location? Center => Locations is null || Locations.Count == 0 ? null : new Location(
             Locations.Select(l => l.Latitude).Sum() / Locations.Count,
@@ -25,6 +28,8 @@ namespace PhotoLocator.Gps
                 return GpxDecoder.DecodeStream(file).ToArray();
             if (ext == ".kml")
                 return KmlDecoder.DecodeStream(file, minimumInterval).ToArray();
+            if (ext == ".json")
+                return TimelineDecoder.DecodeStream(file, minimumInterval).ToArray();
             throw new FileFormatException("Unsupported file format");
         }
     }

--- a/PhotoLocator/Gps/GpsTrace.cs
+++ b/PhotoLocator/Gps/GpsTrace.cs
@@ -24,12 +24,19 @@ namespace PhotoLocator.Gps
         {
             var ext = Path.GetExtension(fileName).ToLowerInvariant();
             using var file = File.OpenRead(fileName);
-            if (ext == ".gpx")
-                return GpxDecoder.DecodeStream(file).ToArray();
-            if (ext == ".kml")
-                return KmlDecoder.DecodeStream(file, minimumInterval).ToArray();
-            if (ext == ".json")
-                return TimelineDecoder.DecodeStream(file, minimumInterval).ToArray();
+            try
+            {
+                if (ext == ".gpx")
+                    return GpxDecoder.DecodeStream(file).ToArray();
+                if (ext == ".kml")
+                    return KmlDecoder.DecodeStream(file, minimumInterval).ToArray();
+                if (ext == ".json")
+                    return TimelineDecoder.DecodeStream(file).ToArray();
+            }
+            catch (Exception ex)
+            {
+                throw new FileFormatException("Error decoding GPS trace file " + fileName, ex);
+            }
             throw new FileFormatException("Unsupported file format");
         }
     }

--- a/PhotoLocator/Gps/TimelineDecoder.cs
+++ b/PhotoLocator/Gps/TimelineDecoder.cs
@@ -1,0 +1,54 @@
+﻿using MapControl;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+
+namespace PhotoLocator.Gps
+{
+    static class TimelineDecoder
+    {
+        public static IEnumerable<GpsTrace> DecodeStream(Stream stream, TimeSpan minimumInterval)
+        {
+            var document = JsonDocument.Parse(stream);
+            if (!document.RootElement.TryGetProperty("semanticSegments", out var segments))
+                yield break;
+
+            foreach (var segment in segments.EnumerateArray())
+            {
+                if (segment.TryGetProperty("timelinePath", out var timelinePath))
+                {
+                    var trace = new GpsTrace();
+                    foreach (var location in timelinePath.EnumerateArray())
+                        if (location.TryGetProperty("point", out var point) && location.TryGetProperty("time", out var time))
+                        {
+                            var coords = point.GetString()!.Split([',', '°'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                            trace.Locations.Add(new Location(
+                                double.Parse(coords[0], CultureInfo.InvariantCulture),
+                                double.Parse(coords[1], CultureInfo.InvariantCulture)));
+                            trace.TimeStamps.Add(time.GetDateTimeOffset().UtcDateTime);
+                        }
+                    yield return trace;
+                }
+                //else if (segment.TryGetProperty("visit", out var visit)
+                //    && visit.TryGetProperty("topCandidate", out var topCandidate)
+                //    && topCandidate.TryGetProperty("placeLocation", out var placeLocation))
+                //{
+                //    var trace = new GpsTrace();
+                //    var point = placeLocation.GetProperty("latLng").GetString()!.Split([',', '°'], StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                //    trace.Locations.Add(new Location(
+                //        double.Parse(point[0], CultureInfo.InvariantCulture),
+                //        double.Parse(point[1], CultureInfo.InvariantCulture)));
+
+                //    var time = segment.GetProperty("startTime").GetDateTimeOffset();
+                //    trace.TimeStamps.Add(time.UtcDateTime);
+
+                //    trace.Name = time.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+            
+                //    yield return trace;
+                //}
+            }
+        }
+    }
+}

--- a/PhotoLocator/Gps/TimelineDecoder.cs
+++ b/PhotoLocator/Gps/TimelineDecoder.cs
@@ -19,10 +19,15 @@ namespace PhotoLocator.Gps
                 yield break;
             }
 
+            var cutoffDate = DateTime.Now - TimeSpan.FromDays(365);
+
             foreach (var segment in segments.EnumerateArray())
             {
-                if (segment.TryGetProperty("timelinePath", out var timelinePath))
+                if (segment.TryGetProperty("timelinePath", out var timelinePath) && segment.TryGetProperty("startTime", out var startTime))
                 {
+                    if (startTime.GetDateTimeOffset() < cutoffDate)
+                        continue;
+
                     var trace = new GpsTrace();
                     foreach (var location in timelinePath.EnumerateArray())
                         if (location.TryGetProperty("point", out var point) && location.TryGetProperty("time", out var time))
@@ -45,12 +50,8 @@ namespace PhotoLocator.Gps
                 //    trace.Locations.Add(new Location(
                 //        double.Parse(point[0], CultureInfo.InvariantCulture),
                 //        double.Parse(point[1], CultureInfo.InvariantCulture)));
-
-                //    var time = segment.GetProperty("startTime").GetDateTimeOffset();
-                //    trace.TimeStamps.Add(time.UtcDateTime);
-
+                //    trace.TimeStamps.Add(startTime.UtcDateTime);
                 //    trace.Name = time.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-            
                 //    yield return trace;
                 //}
             }

--- a/PhotoLocator/MainViewModel.cs
+++ b/PhotoLocator/MainViewModel.cs
@@ -1084,7 +1084,7 @@ namespace PhotoLocator
                     {
                         await AddOrUpdateItemAsync(e.FullPath, true, false);
                     }
-                    else if (ext is ".gpx" or ".kml")
+                    else if (GpsTrace.TraceExtensions.Contains(ext))
                     {
                         var traces = await Task.Run(() => GpsTrace.DecodeGpsTraceFile(e.FullPath, TimeSpan.FromMinutes(1)));
                         foreach (var trace in traces)
@@ -1150,7 +1150,7 @@ namespace PhotoLocator
                 var ext = Path.GetExtension(fileName).ToLowerInvariant();
                 if (extensions.Contains(ext))
                     Items.InsertOrdered(new PictureItemViewModel(fileName, false, HandleFilePropertyChanged, Settings));
-                else if (ext is ".gpx" or ".kml" && !_gpsTraceFiles.Contains(fileName))
+                else if (GpsTrace.TraceExtensions.Contains(ext) && !_gpsTraceFiles.Contains(fileName))
                 {
                     _gpsTraceFiles.Add(fileName);
                     var traces = await Task.Run(() => GpsTrace.DecodeGpsTraceFile(fileName, TimeSpan.FromMinutes(1)));

--- a/PhotoLocatorTest/Gps/GpsTraceTest.cs
+++ b/PhotoLocatorTest/Gps/GpsTraceTest.cs
@@ -1,4 +1,3 @@
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using System.Xml;
 
 namespace PhotoLocator.Gps
@@ -64,6 +63,17 @@ namespace PhotoLocator.Gps
 
             Assert.AreEqual(2, trace.Locations.Count);
             Assert.AreEqual(DateTimeKind.Utc, trace.TimeStamps[0].Kind);
+        }
+
+        [TestMethod, Ignore]
+        public void TimelineDecoder_ShouldDecodeTimeline()
+        {
+            using var stream = File.OpenRead(@"TestData\Tidslinje.json");
+
+            var trace = TimelineDecoder.DecodeStream(stream, TimeSpan.FromMinutes(15)).ToArray();
+
+            Assert.AreEqual(2, trace[0].Locations.Count);
+            Assert.AreEqual(DateTimeKind.Utc, trace[0].TimeStamps[0].Kind);
         }
 
         [TestMethod, Ignore]

--- a/PhotoLocatorTest/Gps/GpsTraceTest.cs
+++ b/PhotoLocatorTest/Gps/GpsTraceTest.cs
@@ -65,12 +65,16 @@ namespace PhotoLocator.Gps
             Assert.AreEqual(DateTimeKind.Utc, trace.TimeStamps[0].Kind);
         }
 
-        [TestMethod, Ignore]
+        [TestMethod]
         public void TimelineDecoder_ShouldDecodeTimeline()
         {
-            using var stream = File.OpenRead(@"TestData\Tidslinje.json");
+            const string TimelineJsonPath = @"TestData\Timeline.json";
 
-            var trace = TimelineDecoder.DecodeStream(stream, TimeSpan.FromMinutes(15)).ToArray();
+            if (!File.Exists(TimelineJsonPath))
+                Assert.Inconclusive("Test data not available");
+
+            using var stream = File.OpenRead(TimelineJsonPath);
+            var trace = TimelineDecoder.DecodeStream(stream).ToArray();
 
             Assert.AreEqual(2, trace[0].Locations.Count);
             Assert.AreEqual(DateTimeKind.Utc, trace[0].TimeStamps[0].Kind);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for importing GPS trace files in JSON format, in addition to GPX and KML.
- **Improvements**
  - Generalized file handling to automatically recognize all supported GPS trace file extensions.
- **Tests**
  - Added a test for decoding JSON timeline GPS traces.
- **Chores**
  - Removed an unused directive to improve code cleanliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->