### PR TITLE
Paste metadata from copied file

### DIFF
--- a/PhotoLocator/MainViewModel.cs
+++ b/PhotoLocator/MainViewModel.cs
@@ -545,7 +545,7 @@ namespace PhotoLocator
             await RunProcessWithProgressBarAsync(async (progressCallback, ct) =>
             {
                 progressCallback(-1);
-                await ExifHandler.TransferMetadataAsync(sourceFileName, SelectedItem.FullPath, SelectedItem.GetProcessedFileName(),
+                await ExifTool.TransferMetadataAsync(sourceFileName, SelectedItem.FullPath, SelectedItem.GetProcessedFileName(),
                     Settings.ExifToolPath ?? throw new UserMessageException(ExifToolNotConfigured), ct);
             }, "Pasting metadata...");
         });
@@ -908,7 +908,7 @@ namespace PhotoLocator
                 await Parallel.ForEachAsync(selectedItems, new ParallelOptions { MaxDegreeOfParallelism = MaxParallelExifToolOperations, CancellationToken = ct }, 
                     async (item, ct) =>
                     {
-                        await ExifHandler.AdjustTimeStampAsync(item.FullPath, item.GetProcessedFileName(), offset, 
+                        await ExifTool.AdjustTimeStampAsync(item.FullPath, item.GetProcessedFileName(), offset, 
                             Settings.ExifToolPath ?? throw new UserMessageException(ExifToolNotConfigured), ct);
                         progressCallback((double)Interlocked.Increment(ref i) / selectedItems.Length);
                     });
@@ -926,7 +926,7 @@ namespace PhotoLocator
                 metadataWin.Owner = App.Current.MainWindow;
                 metadataWin.Title = SelectedItem.Name;
                 if (Settings.ForceUseExifTool && !string.IsNullOrEmpty(Settings.ExifToolPath))
-                    metadataWin.Metadata = String.Join("\n", ExifHandler.EnumerateMetadataUsingExifTool(SelectedItem.FullPath, Settings.ExifToolPath));
+                    metadataWin.Metadata = String.Join("\n", ExifTool.EnumerateMetadata(SelectedItem.FullPath, Settings.ExifToolPath));
                 else
                     metadataWin.Metadata = String.Join("\n", ExifHandler.EnumerateMetadata(SelectedItem.FullPath, Settings.ExifToolPath));
             }

--- a/PhotoLocator/MainViewModel.cs
+++ b/PhotoLocator/MainViewModel.cs
@@ -30,6 +30,8 @@ namespace PhotoLocator
     {
         private const int MaxParallelExifToolOperations = 1;
 
+        private const string ExifToolNotConfigured = "ExifTool not configured";
+
 #if DEBUG
         static readonly bool _isInDesignMode = DesignerProperties.GetIsInDesignMode(new DependencyObject());
 #else
@@ -544,7 +546,7 @@ namespace PhotoLocator
             {
                 progressCallback(-1);
                 await ExifHandler.TransferMetadataAsync(sourceFileName, SelectedItem.FullPath, SelectedItem.GetProcessedFileName(),
-                    Settings.ExifToolPath ?? throw new UserMessageException("ExifTool not configured"), ct);
+                    Settings.ExifToolPath ?? throw new UserMessageException(ExifToolNotConfigured), ct);
             }, "Pasting metadata...");
         });
 
@@ -906,7 +908,8 @@ namespace PhotoLocator
                 await Parallel.ForEachAsync(selectedItems, new ParallelOptions { MaxDegreeOfParallelism = MaxParallelExifToolOperations, CancellationToken = ct }, 
                     async (item, ct) =>
                     {
-                        await ExifHandler.AdjustTimeStampAsync(item.FullPath, item.GetProcessedFileName(), offset, Settings.ExifToolPath, ct);
+                        await ExifHandler.AdjustTimeStampAsync(item.FullPath, item.GetProcessedFileName(), offset, 
+                            Settings.ExifToolPath ?? throw new UserMessageException(ExifToolNotConfigured), ct);
                         progressCallback((double)Interlocked.Increment(ref i) / selectedItems.Length);
                     });
                 await Task.Delay(10, ct);

--- a/PhotoLocator/MainWindow.xaml
+++ b/PhotoLocator/MainWindow.xaml
@@ -138,6 +138,7 @@
                 <KeyBinding Key="OemMinus" Command="{Binding DeselectAllCommand}" />
                 <KeyBinding Key="Divide" Command="{Binding QuickSearchCommand}" />
                 <KeyBinding Key="Insert" Modifiers="Ctrl" Command="{Binding CopyFilesToClipboardCommand}" />
+                <KeyBinding Key="Insert" Modifiers="Shift" Command="{Binding PasteLocationCommand}" />
             </ListBox.InputBindings>
             <ListBox.ContextMenu>
                 <ContextMenu>
@@ -152,6 +153,7 @@
                         <MenuItem Header="Adjust timestamps" Command="{Binding AdjustTimestampsCommand}"/>
                         <MenuItem Header="Auto geotag (Ctrl+T)" Command="{Binding AutoGeotagCommand}"/>
                         <MenuItem Header="Save changed geotags to files (Ctrl+S)" Command="{Binding SaveGeotagsCommand}"/>
+                        <MenuItem Header="Paste metadata from copied file" Command="{Binding PasteMetadataCommand}"/>
                         <MenuItem Header="Show metadata" Command="{Binding ShowMetadataCommand}" />
                     </MenuItem>
                     <Separator />

--- a/PhotoLocator/MainWindow.xaml.cs
+++ b/PhotoLocator/MainWindow.xaml.cs
@@ -198,10 +198,10 @@ namespace PhotoLocator
                 selectedItem.IsChecked = !selectedItem.IsChecked;
                 e.Handled = true;
             }
-            else if (e.Key == Key.Insert && !e.KeyboardDevice.IsKeyDown(Key.LeftCtrl) && !e.KeyboardDevice.IsKeyDown(Key.RightCtrl))
+            else if (e.Key == Key.Insert && !e.KeyboardDevice.IsKeyDown(Key.LeftCtrl) && !e.KeyboardDevice.IsKeyDown(Key.RightCtrl) 
+                && !e.KeyboardDevice.IsKeyDown(Key.LeftShift) && !e.KeyboardDevice.IsKeyDown(Key.RightShift))
             {
-                if (!(e.KeyboardDevice.IsKeyDown(Key.LeftShift) || e.KeyboardDevice.IsKeyDown(Key.RightShift)))
-                    selectedItem.IsChecked = !selectedItem.IsChecked;
+                selectedItem.IsChecked = !selectedItem.IsChecked;
                 if (PictureListBox.SelectedIndex < PictureListBox.Items.Count - 1)
                 {
                     PictureListBox.SelectedItem = PictureListBox.Items[PictureListBox.SelectedIndex + 1];
@@ -497,15 +497,16 @@ namespace PhotoLocator
             var MaxHeight = PreviewCanvas.ActualHeight * screenDpi.DpiScaleY;
             var scale = Math.Min(maxWidth / sourceImage.PixelWidth, MaxHeight / sourceImage.PixelHeight);
             BitmapSource? resampled = null;
-            var sw = Stopwatch.StartNew();
             if (scale > 1 && _viewModel.Settings.LanczosUpscaling || scale < 1 && _viewModel.Settings.LanczosDownscaling)
             {
+                var sw = Stopwatch.StartNew();
                 var resizeOperation = new LanczosResizeOperation();
                 _resamplerCancellation = new CancellationTokenSource();
                 resampled = await Task.Run(() => resizeOperation.Apply(sourceImage,
                     (int)(sourceImage.PixelWidth * scale), (int)(sourceImage.PixelHeight * scale),
                     screenDpi.PixelsPerInchX, screenDpi.PixelsPerInchY,
                     _resamplerCancellation.Token), _resamplerCancellation.Token);
+                Log.Write($"Resampled image to {resampled?.PixelWidth}x{resampled?.PixelHeight} in {sw.ElapsedMilliseconds} ms");
             }
             if (sourceImage == _viewModel.PreviewPictureSource)
             {
@@ -523,7 +524,6 @@ namespace PhotoLocator
                     FullPreviewImage.Visibility = Visibility.Collapsed;
                 }
                 ZoomedPreviewImage.Visibility = Visibility.Collapsed;
-                Log.Write($"Resampled image to {resampled?.PixelWidth}x{resampled?.PixelHeight} in {sw.ElapsedMilliseconds} ms");
             }
         }
 

--- a/PhotoLocator/Metadata/ExifHandler.cs
+++ b/PhotoLocator/Metadata/ExifHandler.cs
@@ -431,7 +431,7 @@ namespace PhotoLocator.Metadata
                                 using var tagDecoder = new IfdDecoder(imageStream, 12);
                                 var timeZone = tagDecoder.DecodeUInt32Tag(tag);
                                 offset = TimeSpan.FromMinutes((Int16)(timeZone[1]));
-                                if (Math.Abs(offset.TotalHours) < 14)
+                                if (Math.Abs(offset.TotalHours) <= 14)
                                     return new DateTimeOffset(timeStamp, offset);
                             }
                     }

--- a/PhotoLocator/Metadata/ExifHandler.cs
+++ b/PhotoLocator/Metadata/ExifHandler.cs
@@ -5,7 +5,6 @@ using PhotoLocator.Helpers;
 using PhotoLocator.PictureFileFormats;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -76,8 +75,6 @@ namespace PhotoLocator.Metadata
         private const string ExifMakerNoteQuery1 = "/app1/{ushort=0}/{ushort=34665}/{ushort=37500}";
 
         public const BitmapCreateOptions CreateOptions = BitmapCreateOptions.PreservePixelFormat | BitmapCreateOptions.IgnoreColorProfile;
-        
-        private const string ExifToolStartError = "Failed to start ExifTool";
 
         /// <summary> Note that the stream must still be valid when the metadata is used </summary>
         public static BitmapMetadata? LoadMetadata(Stream stream)
@@ -318,62 +315,6 @@ namespace PhotoLocator.Metadata
             memoryStream.CopyTo(targetFileStream);
         }
 
-        public static async Task SetGeotagAsync(string sourceFileName, string targetFileName, Location location, string? exifToolPath, CancellationToken ct)
-        {
-            if (string.IsNullOrEmpty(exifToolPath))
-            {
-                SetJpegGeotag(sourceFileName, targetFileName, location);
-                return;
-            }
-
-            var startInfo = new ProcessStartInfo(exifToolPath,
-                //"-m " + // Ignore minor errors and warnings
-                $"-GPSLatitude={location.Latitude.ToString(CultureInfo.InvariantCulture)} " +
-                $"-GPSLatitudeRef={Math.Sign(location.Latitude)} " +
-                $"-GPSLongitude={location.Longitude.ToString(CultureInfo.InvariantCulture)} " +
-                $"-GPSLongitudeRef={Math.Sign(location.Longitude)} " +
-                $"\"{sourceFileName}\" ");
-            if (targetFileName == sourceFileName)
-                startInfo.Arguments += "-overwrite_original";
-            else
-            {
-                File.Delete(targetFileName);
-                startInfo.Arguments += $"-out \"{targetFileName}\"";
-            }
-            startInfo.CreateNoWindow = true;
-            startInfo.RedirectStandardOutput = true;
-            startInfo.RedirectStandardError = true;
-            var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
-            var output = await process.StandardOutput.ReadToEndAsync(ct) + '\n' + await process.StandardError.ReadToEndAsync(ct);
-            await process.WaitForExitAsync(ct);
-            Log.Write(output);
-            if (process.ExitCode != 0)
-                throw new UserMessageException(output);
-        }
-
-        public static async Task AdjustTimeStampAsync(string sourceFileName, string targetFileName, string offset, string exifToolPath, CancellationToken ct)
-        {
-            var sign = offset[0];
-            offset = offset[1..];
-            var startInfo = new ProcessStartInfo(exifToolPath, $"\"-AllDates{sign}={offset}\" \"{sourceFileName}\" ");
-            if (targetFileName == sourceFileName)
-                startInfo.Arguments += "-overwrite_original";
-            else
-            {
-                File.Delete(targetFileName);
-                startInfo.Arguments += $"-out \"{targetFileName}\"";
-            }
-            startInfo.CreateNoWindow = true;
-            startInfo.RedirectStandardOutput = true;
-            startInfo.RedirectStandardError = true;
-            var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
-            var output = await process.StandardOutput.ReadToEndAsync(ct) + '\n' + await process.StandardError.ReadToEndAsync(ct);  // We must read before waiting
-            await process.WaitForExitAsync(ct);
-            Log.Write(output);
-            if (process.ExitCode != 0)
-                throw new UserMessageException(output);
-        }
-
         private static void CheckPixels(BitmapFrame frame1, BitmapFrame frame2)
         {
             if (frame1.PixelWidth != frame2.PixelWidth || frame1.PixelHeight != frame2.PixelHeight)
@@ -490,7 +431,7 @@ namespace PhotoLocator.Metadata
                                 using var tagDecoder = new IfdDecoder(imageStream, 12);
                                 var timeZone = tagDecoder.DecodeUInt32Tag(tag);
                                 offset = TimeSpan.FromMinutes((Int16)(timeZone[1]));
-                                if (offset.TotalHours < 13)
+                                if (Math.Abs(offset.TotalHours) < 14)
                                     return new DateTimeOffset(timeStamp, offset);
                             }
                     }
@@ -538,7 +479,7 @@ namespace PhotoLocator.Metadata
             {
                 if (string.IsNullOrEmpty(exifToolPath))
                     throw;
-                return EnumerateMetadataUsingExifTool(fileName, exifToolPath);
+                return ExifTool.EnumerateMetadata(fileName, exifToolPath);
             }
         }
 
@@ -610,17 +551,6 @@ namespace PhotoLocator.Metadata
             }
         }
 
-        public static string[] EnumerateMetadataUsingExifTool(string fileName, string exifToolPath)
-        {
-            var startInfo = new ProcessStartInfo(exifToolPath, $"-s2 -c +%.6f \"{fileName}\""); // -H to add hexadecimal values
-            startInfo.CreateNoWindow = true;
-            startInfo.RedirectStandardOutput = true;
-            var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
-            var output = process.StandardOutput.ReadToEnd();
-            process.WaitForExit();
-            return output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        }
-
         public static string GetMetadataString(BitmapMetadata metadata, Stream? imageStream)
         {
             return GetMetadataString(metadata, DecodeTimeStamp(metadata, imageStream));
@@ -670,15 +600,16 @@ namespace PhotoLocator.Metadata
             return string.Join(", ", metadataStrings);
         }
 
-        private static string FormatTimestampForDisplay(DateTimeOffset timestamp)
+        internal static string FormatTimestampForDisplay(DateTimeOffset timestamp)
         {
             return timestamp.ToString(CultureInfo.CurrentCulture);
         }
 
-        public static async Task<(Location? Location, DateTimeOffset? TimeStamp, string Metadata, Rotation Orientation)> DecodeMetadataAsync(string fileName, bool isVideo, string? exifToolPath, CancellationToken ct)
+        public static async Task<(Location? Location, DateTimeOffset? TimeStamp, string Metadata, Rotation Orientation)> DecodeMetadataAsync(
+            string fileName, bool isVideo, string? exifToolPath, CancellationToken ct)
         {
             if (isVideo && !string.IsNullOrEmpty(exifToolPath))
-                return DecodeMetadataUsingExifTool(fileName, exifToolPath);
+                return ExifTool.DecodeMetadata(fileName, exifToolPath);
             try
             {
                 using var file = await FileHelpers.OpenFileWithRetryAsync(fileName, ct);
@@ -700,141 +631,8 @@ namespace PhotoLocator.Metadata
             {
                 if (string.IsNullOrEmpty(exifToolPath))
                     throw;
-                return DecodeMetadataUsingExifTool(fileName, exifToolPath);
+                return ExifTool.DecodeMetadata(fileName, exifToolPath);
             }
-        }
-
-        public static Dictionary<string, string> LoadMetadataUsingExifTool(string fileName, string exifToolPath)
-        {
-            return DecodeExifToolMetadataToDictionary(EnumerateMetadataUsingExifTool(fileName, exifToolPath));
-        }
-
-        public static (Location? Location, DateTimeOffset? TimeStamp, string Metadata, Rotation Orientation) DecodeMetadataUsingExifTool(string fileName, string exifToolPath)
-        {
-            var metadata = LoadMetadataUsingExifTool(fileName, exifToolPath);
-
-            var metadataStrings = new List<string>();
-            if (metadata.TryGetValue("Model", out var value) || metadata.TryGetValue("Encoder", out value))
-                metadataStrings.Add(value);
-            if (metadata.TryGetValue("ExposureTime", out value) && value != "undef")
-                metadataStrings.Add(value + "s");
-            if (metadata.TryGetValue("ApertureValue", out value))
-                metadataStrings.Add("f/" + value);
-            if (metadata.TryGetValue("FocalLength", out value))
-                metadataStrings.Add(value);
-            if (metadata.TryGetValue("ISO", out value))
-                metadataStrings.Add("ISO" + value);
-            if (metadata.TryGetValue("ImageSize", out value))
-                metadataStrings.Add(value);
-            if (metadata.TryGetValue("VideoFrameRate", out value) && value != "1")
-            {
-                metadataStrings.Add(value + "fps");
-                if (metadata.TryGetValue("Duration", out value))
-                    metadataStrings.Add(value);
-                if (metadata.TryGetValue("AvgBitrate", out value))
-                    metadataStrings.Add(value);
-            }
-
-            var creationTimestamp = DecodeTimeStampFromExifTool(metadata);
-            if (creationTimestamp.HasValue)
-                metadataStrings.Add(FormatTimestampForDisplay(creationTimestamp.Value));
-            var location = DecodeLocationFromExifTool(metadata);
-            var orientation = DecodeOrientationFromExifTool(metadata);
-
-            return (location, creationTimestamp, string.Join(", ", metadataStrings), orientation);
-        }
-
-        internal static Dictionary<string, string> DecodeExifToolMetadataToDictionary(string[] lines)
-        {
-            var metadata = new Dictionary<string, string>();
-            foreach (var line in lines)
-            {
-                var index = line.IndexOf(':', StringComparison.Ordinal);
-                if (index < line.Length - 2)
-                    metadata[line[..index]] = line[(index + 2)..];
-            }
-            return metadata;
-        }
-
-        internal static DateTimeOffset? DecodeTimeStampFromExifTool(Dictionary<string, string> metadata)
-        {
-            if (!metadata.TryGetValue("SubSecCreateDate", out var timeStampStr) &&
-                !metadata.TryGetValue("SubSecDateTimeOriginal", out timeStampStr) &&
-                !metadata.TryGetValue("CreationDate", out timeStampStr) &&
-                !metadata.TryGetValue("CreateDate", out timeStampStr) &&
-                !metadata.TryGetValue("DateTimeOriginal", out timeStampStr))
-                return null;
-            var fractionStart = timeStampStr.IndexOf('.', StringComparison.Ordinal);
-            if (fractionStart > 0)
-            {
-                var fractionEnd = timeStampStr.IndexOfAny(['+', '-'], fractionStart);
-                if (fractionEnd > 0)
-                    timeStampStr = string.Concat(timeStampStr.AsSpan(0, fractionStart), timeStampStr.AsSpan(fractionEnd));
-                else
-                    timeStampStr = timeStampStr[..fractionStart];
-            }
-            if (DateTimeOffset.TryParseExact(timeStampStr, "yyyy:MM:dd HH:mm:sszzz", CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var timestampOffset))
-                return timestampOffset;
-            if (metadata.TryGetValue("OffsetTimeOriginal", out var offsetStr) ||
-                metadata.TryGetValue("OffsetTime", out offsetStr) ||
-                metadata.TryGetValue("TimeZone", out offsetStr))
-            {
-                var timeStampWithOffsetStr = timeStampStr + offsetStr;
-                if (DateTimeOffset.TryParseExact(timeStampWithOffsetStr, "yyyy:MM:dd HH:mm:sszzz", CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out timestampOffset))
-                    return timestampOffset;
-            }
-            var timeZone = metadata.TryGetValue("FileType", out var fileType) && fileType=="JPEG" ? DateTimeStyles.AssumeLocal : DateTimeStyles.AssumeUniversal;
-            if (DateTime.TryParseExact(timeStampStr, "yyyy:MM:dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces | timeZone, out var timestamp))
-                return timestamp;
-            return null;
-        }
-
-        private static Rotation DecodeOrientationFromExifTool(Dictionary<string, string> metadata)
-        {
-            if (!metadata.TryGetValue("Orientation", out var orientationStr))
-                return Rotation.Rotate0;
-            return orientationStr switch
-            {
-                "Rotate 90 CW" or "6" => Rotation.Rotate90,
-                "Rotate 180" or "3" => Rotation.Rotate180,
-                "Rotate 270 CW" or "8" => Rotation.Rotate270,
-                _ => Rotation.Rotate0
-            };
-        }
-
-        private static Location? DecodeLocationFromExifTool(Dictionary<string, string> metadata)
-        {
-            if (metadata.TryGetValue("GPSPosition", out var locationStr) ||
-                metadata.TryGetValue("GPSCoordinates", out locationStr))
-            {
-                var parts = locationStr.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length >= 4 &&
-                    double.TryParse(parts[0], CultureInfo.InvariantCulture, out var latitude) &&
-                    double.TryParse(parts[2], CultureInfo.InvariantCulture, out var longitude))
-                    return new Location(latitude, longitude);
-            }
-            return null;
-        }
-
-        public static async Task TransferMetadataAsync(string metadataFileName, string sourceFileName, string targetFileName, string exifToolPath, CancellationToken ct)
-        {
-            var startInfo = new ProcessStartInfo(exifToolPath, $"-tagsfromfile \"{metadataFileName}\" \"{sourceFileName}\" "); // -exif 
-            startInfo.CreateNoWindow = true;
-            startInfo.RedirectStandardOutput = true;
-            startInfo.RedirectStandardError = true;
-            if (targetFileName == sourceFileName)
-                startInfo.Arguments += "-overwrite_original";
-            else
-            {
-                File.Delete(targetFileName);
-                startInfo.Arguments += $"-out \"{targetFileName}\"";
-            }
-            var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
-            var output = await process.StandardOutput.ReadToEndAsync(ct) + '\n' + await process.StandardError.ReadToEndAsync(ct);
-            await process.WaitForExitAsync(ct);
-            Log.Write(output);
-            if (process.ExitCode != 0)
-                throw new UserMessageException("Failed to transfer metadata: " + output);
-        }
+        }             
     }
 }

--- a/PhotoLocator/Metadata/ExifTool.cs
+++ b/PhotoLocator/Metadata/ExifTool.cs
@@ -1,0 +1,192 @@
+﻿using MapControl;
+using PhotoLocator.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+
+namespace PhotoLocator.Metadata;
+
+static class ExifTool
+{
+    private const string ExifToolStartError = "Failed to start ExifTool";
+
+    public static async Task AdjustTimeStampAsync(string sourceFileName, string targetFileName, string offset, string exifToolPath, CancellationToken ct)
+    {
+        var sign = offset[0];
+        offset = offset[1..];
+        var startInfo = new ProcessStartInfo(exifToolPath, $"\"-AllDates{sign}={offset}\" \"{sourceFileName}\" ");
+        await RunExifToolAsync(sourceFileName, targetFileName, startInfo, ct);
+    }
+
+    public static async Task TransferMetadataAsync(string metadataFileName, string sourceFileName, string targetFileName, string exifToolPath, CancellationToken ct)
+    {
+        var startInfo = new ProcessStartInfo(exifToolPath, $"-tagsfromfile \"{metadataFileName}\" \"{sourceFileName}\" "); // -exif 
+        await RunExifToolAsync(sourceFileName, targetFileName, startInfo, ct);
+    }
+
+    public static async Task SetGeotagAsync(string sourceFileName, string targetFileName, Location location, string? exifToolPath, CancellationToken ct)
+    {
+        if (string.IsNullOrEmpty(exifToolPath))
+        {
+            ExifHandler.SetJpegGeotag(sourceFileName, targetFileName, location);
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo(exifToolPath,
+            //"-m " + // Ignore minor errors and warnings
+            $"-GPSLatitude={location.Latitude.ToString(CultureInfo.InvariantCulture)} " +
+            $"-GPSLatitudeRef={Math.Sign(location.Latitude)} " +
+            $"-GPSLongitude={location.Longitude.ToString(CultureInfo.InvariantCulture)} " +
+            $"-GPSLongitudeRef={Math.Sign(location.Longitude)} " +
+            $"\"{sourceFileName}\" ");
+        await RunExifToolAsync(sourceFileName, targetFileName, startInfo, ct);
+    }
+
+    private static async Task RunExifToolAsync(string sourceFileName, string targetFileName, ProcessStartInfo startInfo, CancellationToken ct)
+    {
+        if (targetFileName == sourceFileName)
+            startInfo.Arguments += "-overwrite_original";
+        else
+        {
+            File.Delete(targetFileName);
+            startInfo.Arguments += $"-out \"{targetFileName}\"";
+        }
+        startInfo.CreateNoWindow = true;
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
+        var output = await process.StandardOutput.ReadToEndAsync(ct) + '\n' + await process.StandardError.ReadToEndAsync(ct);
+        await process.WaitForExitAsync(ct);
+        Log.Write(output);
+        if (process.ExitCode != 0)
+            throw new UserMessageException(output);
+    }
+
+    public static string[] EnumerateMetadata(string fileName, string exifToolPath)
+    {
+        var startInfo = new ProcessStartInfo(exifToolPath, $"-s2 -c +%.6f \"{fileName}\""); // -H to add hexadecimal values
+        startInfo.CreateNoWindow = true;
+        startInfo.RedirectStandardOutput = true;
+        var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
+        var output = process.StandardOutput.ReadToEnd();
+        process.WaitForExit();
+        return output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    public static Dictionary<string, string> LoadMetadata(string fileName, string exifToolPath)
+    {
+        return DecodeMetadataToDictionary(EnumerateMetadata(fileName, exifToolPath));
+    }
+
+    internal static Dictionary<string, string> DecodeMetadataToDictionary(string[] lines)
+    {
+        var metadata = new Dictionary<string, string>();
+        foreach (var line in lines)
+        {
+            var index = line.IndexOf(':', StringComparison.Ordinal);
+            if (index < line.Length - 2)
+                metadata[line[..index]] = line[(index + 2)..];
+        }
+        return metadata;
+    }
+
+    public static (Location? Location, DateTimeOffset? TimeStamp, string Metadata, Rotation Orientation) DecodeMetadata(string fileName, string exifToolPath)
+    {
+        var metadata = LoadMetadata(fileName, exifToolPath);
+
+        var metadataStrings = new List<string>();
+        if (metadata.TryGetValue("Model", out var value) || metadata.TryGetValue("Encoder", out value))
+            metadataStrings.Add(value);
+        if (metadata.TryGetValue("ExposureTime", out value) && value != "undef")
+            metadataStrings.Add(value + "s");
+        if (metadata.TryGetValue("ApertureValue", out value))
+            metadataStrings.Add("f/" + value);
+        if (metadata.TryGetValue("FocalLength", out value))
+            metadataStrings.Add(value);
+        if (metadata.TryGetValue("ISO", out value))
+            metadataStrings.Add("ISO" + value);
+        if (metadata.TryGetValue("ImageSize", out value))
+            metadataStrings.Add(value);
+        if (metadata.TryGetValue("VideoFrameRate", out value) && value != "1")
+        {
+            metadataStrings.Add(value + "fps");
+            if (metadata.TryGetValue("Duration", out value))
+                metadataStrings.Add(value);
+            if (metadata.TryGetValue("AvgBitrate", out value))
+                metadataStrings.Add(value);
+        }
+
+        var creationTimestamp = DecodeTimeStamp(metadata);
+        if (creationTimestamp.HasValue)
+            metadataStrings.Add(ExifHandler.FormatTimestampForDisplay(creationTimestamp.Value));
+        var location = DecodeLocation(metadata);
+        var orientation = DecodeOrientation(metadata);
+
+        return (location, creationTimestamp, string.Join(", ", metadataStrings), orientation);
+    }
+
+    internal static DateTimeOffset? DecodeTimeStamp(Dictionary<string, string> metadata)
+    {
+        if (!metadata.TryGetValue("SubSecCreateDate", out var timeStampStr) &&
+            !metadata.TryGetValue("SubSecDateTimeOriginal", out timeStampStr) &&
+            !metadata.TryGetValue("CreationDate", out timeStampStr) &&
+            !metadata.TryGetValue("CreateDate", out timeStampStr) &&
+            !metadata.TryGetValue("DateTimeOriginal", out timeStampStr))
+            return null;
+        var fractionStart = timeStampStr.IndexOf('.', StringComparison.Ordinal);
+        if (fractionStart > 0)
+        {
+            var fractionEnd = timeStampStr.IndexOfAny(['+', '-'], fractionStart);
+            if (fractionEnd > 0)
+                timeStampStr = string.Concat(timeStampStr.AsSpan(0, fractionStart), timeStampStr.AsSpan(fractionEnd));
+            else
+                timeStampStr = timeStampStr[..fractionStart];
+        }
+        if (DateTimeOffset.TryParseExact(timeStampStr, "yyyy:MM:dd HH:mm:sszzz", CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var timestampOffset))
+            return timestampOffset;
+        if (metadata.TryGetValue("OffsetTimeOriginal", out var offsetStr) ||
+            metadata.TryGetValue("OffsetTime", out offsetStr) ||
+            metadata.TryGetValue("TimeZone", out offsetStr))
+        {
+            var timeStampWithOffsetStr = timeStampStr + offsetStr;
+            if (DateTimeOffset.TryParseExact(timeStampWithOffsetStr, "yyyy:MM:dd HH:mm:sszzz", CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out timestampOffset))
+                return timestampOffset;
+        }
+        var timeZone = metadata.TryGetValue("FileType", out var fileType) && fileType == "JPEG" ? DateTimeStyles.AssumeLocal : DateTimeStyles.AssumeUniversal;
+        if (DateTime.TryParseExact(timeStampStr, "yyyy:MM:dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces | timeZone, out var timestamp))
+            return timestamp;
+        return null;
+    }
+
+    private static Rotation DecodeOrientation(Dictionary<string, string> metadata)
+    {
+        if (!metadata.TryGetValue("Orientation", out var orientationStr))
+            return Rotation.Rotate0;
+        return orientationStr switch
+        {
+            "Rotate 90 CW" or "6" => Rotation.Rotate90,
+            "Rotate 180" or "3" => Rotation.Rotate180,
+            "Rotate 270 CW" or "8" => Rotation.Rotate270,
+            _ => Rotation.Rotate0
+        };
+    }
+
+    private static Location? DecodeLocation(Dictionary<string, string> metadata)
+    {
+        if (metadata.TryGetValue("GPSPosition", out var locationStr) ||
+            metadata.TryGetValue("GPSCoordinates", out locationStr))
+        {
+            var parts = locationStr.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 4 &&
+                double.TryParse(parts[0], CultureInfo.InvariantCulture, out var latitude) &&
+                double.TryParse(parts[2], CultureInfo.InvariantCulture, out var longitude))
+                return new Location(latitude, longitude);
+        }
+        return null;
+    }
+}

--- a/PhotoLocator/Metadata/ExifTool.cs
+++ b/PhotoLocator/Metadata/ExifTool.cs
@@ -17,6 +17,8 @@ static class ExifTool
 
     public static async Task AdjustTimeStampAsync(string sourceFileName, string targetFileName, string offset, string exifToolPath, CancellationToken ct)
     {
+        if (offset is null || offset.Length < 2)
+            throw new UserMessageException("Offset must have a sign followed by a value");
         var sign = offset[0];
         offset = offset[1..];
         var startInfo = new ProcessStartInfo(exifToolPath, $"\"-AllDates{sign}={offset}\" \"{sourceFileName}\" ");
@@ -59,7 +61,7 @@ static class ExifTool
         startInfo.CreateNoWindow = true;
         startInfo.RedirectStandardOutput = true;
         startInfo.RedirectStandardError = true;
-        var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
+        using var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
         var output = await process.StandardOutput.ReadToEndAsync(ct) + '\n' + await process.StandardError.ReadToEndAsync(ct);
         await process.WaitForExitAsync(ct);
         Log.Write(output);
@@ -72,7 +74,7 @@ static class ExifTool
         var startInfo = new ProcessStartInfo(exifToolPath, $"-s2 -c +%.6f \"{fileName}\""); // -H to add hexadecimal values
         startInfo.CreateNoWindow = true;
         startInfo.RedirectStandardOutput = true;
-        var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
+        using var process = Process.Start(startInfo) ?? throw new IOException(ExifToolStartError);
         var output = process.StandardOutput.ReadToEnd();
         process.WaitForExit();
         return output.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);

--- a/PhotoLocator/PictureFileFormats/JpegTransformations.cs
+++ b/PhotoLocator/PictureFileFormats/JpegTransformations.cs
@@ -40,7 +40,7 @@ namespace PhotoLocator.PictureFileFormats
             startInfo.CreateNoWindow = true;
             startInfo.RedirectStandardOutput = true;
             Log.Write($"{startInfo.FileName} {startInfo.Arguments}");
-            var process = Process.Start(startInfo) ?? throw new IOException("Failed to start JpegTransform");
+            using var process = Process.Start(startInfo) ?? throw new IOException("Failed to start JpegTransform");
             var output = process.StandardOutput.ReadToEnd(); // We must read before waiting
             if (!process.WaitForExit(60000))
                 throw new TimeoutException();

--- a/PhotoLocator/PictureItemViewModel.cs
+++ b/PhotoLocator/PictureItemViewModel.cs
@@ -239,7 +239,7 @@ namespace PhotoLocator
             try
             {
                 if (_settings is not null && _settings.ForceUseExifTool && !string.IsNullOrEmpty(_settings.ExifToolPath))
-                    (GeoTag, _timeStamp, _metadataString, Orientation) = await Task.Run(() => ExifHandler.DecodeMetadataUsingExifTool(FullPath, _settings.ExifToolPath), ct);
+                    (GeoTag, _timeStamp, _metadataString, Orientation) = await Task.Run(() => ExifTool.DecodeMetadata(FullPath, _settings.ExifToolPath), ct);
                 else
                     (GeoTag, _timeStamp, _metadataString, Orientation) = await Task.Run(() => ExifHandler.DecodeMetadataAsync(FullPath, IsVideo, _settings?.ExifToolPath, ct), ct);
                 GeoTagSaved = GeoTag != null;
@@ -350,7 +350,7 @@ namespace PhotoLocator
         {
             try
             {
-                await ExifHandler.SetGeotagAsync(FullPath, GetProcessedFileName(),
+                await ExifTool.SetGeotagAsync(FullPath, GetProcessedFileName(),
                     GeoTag ?? throw new InvalidOperationException(nameof(GeoTag) + " not set"),
                     _settings?.ExifToolPath, ct);
                 GeoTagSaved = true;

--- a/PhotoLocator/VideoTransformCommands.cs
+++ b/PhotoLocator/VideoTransformCommands.cs
@@ -694,7 +694,7 @@ namespace PhotoLocator
             {
                 for (int i = 0; i < allSelected.Length; i++)
                 {
-                    var metadata = ExifHandler.LoadMetadataUsingExifTool(allSelected[i].FullPath, _mainViewModel.Settings.ExifToolPath);
+                    var metadata = ExifTool.LoadMetadata(allSelected[i].FullPath, _mainViewModel.Settings.ExifToolPath);
                     var spanStr = metadata["Duration"];
                     if (!double.TryParse(spanStr.Trim('s'), CultureInfo.InvariantCulture, out clipDurations[i]))
                         clipDurations[i] = TimeSpan.Parse(spanStr, CultureInfo.InvariantCulture).TotalSeconds;

--- a/PhotoLocatorTest/Metadata/ExifHandlerTest.cs
+++ b/PhotoLocatorTest/Metadata/ExifHandlerTest.cs
@@ -376,5 +376,45 @@ namespace PhotoLocator.Metadata
             }
             Console.WriteLine(sw.ElapsedMilliseconds);
         }
+
+        [TestMethod]
+        public async Task TransferMetadataAsync_ShouldCopyMetadataToTargetFile()
+        {
+            if (!File.Exists(ExifToolPath))
+                Assert.Inconclusive("ExifTool not found");
+
+            const string MetadataFile = @"TestData\2022-06-17_19.03.02.jpg";
+            const string SourceFile = @"TestData\2025-05-04_15.13.08-04.jpg";
+            const string TargetFile = @"TestData\2025-05-04_15.13.08-04-metadata.jpg";
+            File.Delete(TargetFile);
+
+            await ExifHandler.TransferMetadataAsync(MetadataFile, SourceFile, TargetFile, ExifToolPath, CancellationToken.None);
+
+            var sourceMetadata = ExifHandler.LoadMetadataUsingExifTool(MetadataFile, ExifToolPath);
+            var targetMetadata = ExifHandler.LoadMetadataUsingExifTool(TargetFile, ExifToolPath);
+            Assert.AreEqual(sourceMetadata["Model"], targetMetadata["Model"]);
+            Assert.AreEqual(sourceMetadata["DateTimeOriginal"], targetMetadata["DateTimeOriginal"]);
+            Assert.AreEqual(sourceMetadata["ISO"], targetMetadata["ISO"]);
+        }
+
+        [TestMethod]
+        public async Task TransferMetadataAsync_ShouldWorkInPlace()
+        {
+            if (!File.Exists(ExifToolPath))
+                Assert.Inconclusive("ExifTool not found");
+
+            const string MetadataFile = @"TestData\2022-06-17_19.03.02.jpg";
+            const string SourceFile = @"TestData\2025-05-04_15.13.08-04.jpg";
+            const string TempFile = @"TestData\2025-05-04_15.13.08-04-inplace.jpg";
+            File.Copy(SourceFile, TempFile, true);
+
+            await ExifHandler.TransferMetadataAsync(MetadataFile, TempFile, TempFile, ExifToolPath, CancellationToken.None);
+
+            var sourceMetadata = ExifHandler.LoadMetadataUsingExifTool(MetadataFile, ExifToolPath);
+            var targetMetadata = ExifHandler.LoadMetadataUsingExifTool(TempFile, ExifToolPath);
+            Assert.AreEqual(sourceMetadata["Model"], targetMetadata["Model"]);
+            Assert.AreEqual(sourceMetadata["DateTimeOriginal"], targetMetadata["DateTimeOriginal"]);
+            Assert.AreEqual(sourceMetadata["ISO"], targetMetadata["ISO"]);
+        }
     }
 }

--- a/PhotoLocatorTest/Metadata/ExifHandlerTest.cs
+++ b/PhotoLocatorTest/Metadata/ExifHandlerTest.cs
@@ -9,9 +9,7 @@ namespace PhotoLocator.Metadata
     [TestClass]
     public class ExifHandlerTest
     {
-        const string ExifToolPath = @"exiftool\exiftool(-m).exe";
-
-        static readonly DateTimeOffset _jpegTestDataTimestamp = LocalTimeToDateTimeOffset(new DateTime(2022, 6, 17, 19, 3, 2));
+        public static readonly DateTimeOffset JpegTestDataTimestamp = LocalTimeToDateTimeOffset(new DateTime(2022, 6, 17, 19, 3, 2));
         
         static DateTimeOffset LocalTimeToDateTimeOffset(DateTime dateTime) => new(dateTime, TimeZoneInfo.Local.GetUtcOffset(dateTime));
 
@@ -74,7 +72,7 @@ namespace PhotoLocator.Metadata
             using var targetStream = File.OpenRead(TestFileName);
             var target = ExifHandler.LoadMetadata(targetStream)!;
             Assert.AreEqual(source.CameraModel, target.CameraModel);
-            Assert.AreEqual("FC7303, " + _jpegTestDataTimestamp, ExifHandler.GetMetadataString(target, targetStream));
+            Assert.AreEqual("FC7303, " + JpegTestDataTimestamp, ExifHandler.GetMetadataString(target, targetStream));
             //Assert.AreEqual(ExifHandler.GetGeotag(source), ExifHandler.GetGeotag(target));
         }
 
@@ -93,7 +91,7 @@ namespace PhotoLocator.Metadata
 
             using var targetStream = File.OpenRead(TestFileName);
             var target = ExifHandler.LoadMetadata(targetStream)!;
-            Assert.AreEqual("1/80s, " + _jpegTestDataTimestamp, ExifHandler.GetMetadataString(target, targetStream));
+            Assert.AreEqual("1/80s, " + JpegTestDataTimestamp, ExifHandler.GetMetadataString(target, targetStream));
             Assert.AreEqual(1e-4, ExifHandler.GetGeotag(source)!.Latitude, ExifHandler.GetGeotag(target)!.Latitude);
         }
 
@@ -113,7 +111,7 @@ namespace PhotoLocator.Metadata
 
             using var targetStream = File.OpenRead(TestFileName);
             var target = ExifHandler.LoadMetadata(targetStream)!;
-            Assert.AreEqual("1/80s, " + _jpegTestDataTimestamp, ExifHandler.GetMetadataString(target, targetStream));
+            Assert.AreEqual("1/80s, " + JpegTestDataTimestamp, ExifHandler.GetMetadataString(target, targetStream));
             Assert.AreEqual(1e-4, ExifHandler.GetGeotag(source)!.Longitude, ExifHandler.GetGeotag(target)!.Longitude);
         }
 
@@ -133,7 +131,7 @@ namespace PhotoLocator.Metadata
 
             using var targetStream = File.OpenRead(TestFileName);
             var target = ExifHandler.LoadMetadata(targetStream)!;
-            Assert.AreEqual("1/80s, " + _jpegTestDataTimestamp, ExifHandler.GetMetadataString(target, targetStream));
+            Assert.AreEqual("1/80s, " + JpegTestDataTimestamp, ExifHandler.GetMetadataString(target, targetStream));
             //Assert.AreEqual(ExifHandler.GetGeotag(source), ExifHandler.GetGeotag(target));
         }
 
@@ -167,7 +165,7 @@ namespace PhotoLocator.Metadata
 
             var timeStamp = ExifHandler.DecodeTimeStamp(metadata, stream) ?? throw new FileFormatException("Failed to decode timestamp");
 
-            Assert.AreEqual(_jpegTestDataTimestamp, timeStamp);
+            Assert.AreEqual(JpegTestDataTimestamp, timeStamp);
         }
 
         [TestMethod]
@@ -192,23 +190,7 @@ namespace PhotoLocator.Metadata
             var timeStamp = ExifHandler.DecodeTimeStamp(metadata, stream) ?? throw new FileFormatException("Failed to decode timestamp");
 
             Assert.AreEqual(new(2025, 5, 11, 14, 26, 42, TimeSpan.FromHours(9)), timeStamp);
-        }
-
-        [TestMethod]
-        public async Task AdjustTimestampAsync_ShouldUpdateTimestamp()
-        {
-            if (!File.Exists(ExifToolPath))
-                Assert.Inconclusive("ExifTool not found");
-
-            const string TargetFileName = @"TestData\2022-06-17_18.03.02.jpg";
-
-            await ExifHandler.AdjustTimeStampAsync(@"TestData\2022-06-17_19.03.02.jpg", TargetFileName, "-01:00:00", ExifToolPath, default);
-
-            using var targetFile = File.OpenRead(TargetFileName);
-            var metadata = ExifHandler.LoadMetadata(targetFile);
-            var tag = ExifHandler.DecodeTimeStamp(metadata!, targetFile) ?? throw new FileFormatException("Failed to decode timestamp");
-            Assert.AreEqual(new DateTime(2022, 06, 17, 18, 03, 02, DateTimeKind.Local), tag);
-        }
+        }      
 
         [TestMethod]
         public void GetGeotag_ShouldDecodeGpsCoords()
@@ -248,60 +230,7 @@ namespace PhotoLocator.Metadata
             var tag = ExifHandler.GetGpsAltitude(metadata) ?? throw new FileFormatException("Failed to decode altitude");
 
             Assert.AreEqual(35.0, tag, 0.1);
-        }
-
-        [TestMethod]
-        public async Task SetGeotag_ShouldSet_UsingBitmapMetadata()
-        {
-            var setValue = new MapControl.Location(-10, -20);
-            await ExifHandler.SetGeotagAsync(@"TestData\2022-06-17_19.03.02.jpg", @"TestData\2022-06-17_19.03.02-out1.jpg", setValue, null, default);
-
-            var newValue = ExifHandler.GetGeotag(@"TestData\2022-06-17_19.03.02-out1.jpg");
-            Assert.AreEqual(setValue, newValue);
-        }
-      
-        [TestMethod]
-        public async Task SetGeotag_ShouldSet_UsingExifTool()
-        {
-            if (!File.Exists(ExifToolPath))
-                Assert.Inconclusive("ExifTool not found");
-
-            var setValue = new MapControl.Location(-10, -20);
-            await ExifHandler.SetGeotagAsync(@"TestData\2022-06-17_19.03.02.jpg", @"TestData\2022-06-17_19.03.02-out2.jpg", setValue, ExifToolPath, default);
-
-            var newValue = ExifHandler.GetGeotag(@"TestData\2022-06-17_19.03.02-out2.jpg");
-            Assert.AreEqual(setValue, newValue);
-        }
-
-        [TestMethod]
-        public async Task SetGeotag_ShouldSet_UsingExifTool_InPlace()
-        {
-            if (!File.Exists(ExifToolPath))
-                Assert.Inconclusive("ExifTool not found");
-
-            var setValue = new MapControl.Location(-10, -20);
-            File.Copy(@"TestData\2022-06-17_19.03.02.jpg", @"TestData\2022-06-17_19.03.02_copy.jpg", true);
-            await ExifHandler.SetGeotagAsync(@"TestData\2022-06-17_19.03.02_copy.jpg", @"TestData\2022-06-17_19.03.02_copy.jpg", setValue, ExifToolPath, default);
-
-            var newValue = ExifHandler.GetGeotag(@"TestData\2022-06-17_19.03.02_copy.jpg");
-            Assert.AreEqual(setValue, newValue);
-        }
-
-        [TestMethod]
-        public async Task SetGeotag_ShouldSetInCr3_UsingExifTool()
-        {
-            const string FileName = @"TestData\Test.CR3";
-            if (!File.Exists(FileName))
-                Assert.Inconclusive("Image not found");
-            if (!File.Exists(ExifToolPath))
-                Assert.Inconclusive("ExifTool not found");
-
-            var setValue = new MapControl.Location(-10, -20);
-            await ExifHandler.SetGeotagAsync(FileName, "tagged.cr3", setValue, ExifToolPath, default);
-
-            var newValue = ExifHandler.GetGeotag("tagged.cr3");
-            Assert.AreEqual(setValue, newValue);
-        }
+        }        
 
         [TestMethod]
         public void GetMetadataString_ShouldFormatMetadata()
@@ -313,53 +242,8 @@ namespace PhotoLocator.Metadata
             var metadata = ExifHandler.LoadMetadata(stream);
             Assert.IsNotNull(metadata);
             var str = ExifHandler.GetMetadataString(metadata, stream);
-            Assert.AreEqual("FC7303, 100.7m, 1/80s, f/2.8, 4.49mm, ISO100, " + _jpegTestDataTimestamp, str);
-        }
-
-        [TestMethod]
-        public void DecodeMetadata_ShouldDecodeUsingExifTool()
-        {
-            if (!File.Exists(ExifToolPath))
-                Assert.Inconclusive("ExifTool not found");
-
-            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-
-            var metadata = ExifHandler.DecodeMetadataUsingExifTool(@"TestData\2022-06-17_19.03.02.jpg", ExifToolPath);
-
-            Assert.AreEqual("FC7303, 1/80s, f/2.8, 4.5 mm, ISO100, 341x191, " + _jpegTestDataTimestamp, metadata.Metadata);
-            Assert.AreEqual(new DateTimeOffset(2022, 6, 17, 19, 3, 2, TimeSpan.FromHours(2)), metadata.TimeStamp);
-            Assert.AreEqual(55.4, metadata.Location!.Latitude, 0.1);
-            Assert.AreEqual(11.2, metadata.Location!.Longitude, 0.1);
-        }
-
-        [TestMethod]
-        public void DecodeTimestampFromExifTool_ShouldUseOffset()
-        {
-            var dict = new Dictionary<string, string>
-            {
-                { "DateTimeOriginal", "2025:02:01 22:14:54" },
-                { "OffsetTimeOriginal", "+01:00" }
-            };
-
-            var timestamp = ExifHandler.DecodeTimeStampFromExifTool(dict);
-
-            Assert.AreEqual(new DateTimeOffset(2025, 2, 1, 22, 14, 54, TimeSpan.FromHours(1)), timestamp);
-        }
-
-        [TestMethod]
-        [DataRow(@"TestData\Canon90DVideo.txt", 2024, 7, 9, 14, 38, 53, 0, +2)]
-        [DataRow(@"TestData\DJIAction2Video.txt", 2022, 4, 16, 18, 46, 28, 0, +2)]
-        [DataRow(@"TestData\iPhoneVideo.txt", 2022, 9, 23, 12, 50, 53, 0, +2)]
-        [DataRow(@"TestData\Mini2Video.txt", 2024, 7, 9, 13, 9, 22, 0, +2)]
-        [DataRow(@"TestData\Pixel5Video.txt", 2025, 4, 26, 17, 6, 45, 0, +2)]
-        public void DecodeTimestampFromExifTool_ShouldHandleDifferentFormats(string fileName, int year, int month, int day, int hour, int minutes, int seconds, int ms, int offset)
-        {
-            var metadata = ExifHandler.DecodeExifToolMetadataToDictionary(File.ReadAllLines(fileName));
-
-            var decoded = ExifHandler.DecodeTimeStampFromExifTool(metadata);
-
-            Assert.AreEqual(new DateTimeOffset(year, month, day, hour, minutes, seconds, ms, TimeSpan.FromHours(offset)), decoded);
-        }
+            Assert.AreEqual("FC7303, 100.7m, 1/80s, f/2.8, 4.49mm, ISO100, " + JpegTestDataTimestamp, str);
+        }     
 
         [TestMethod, Ignore]
         public void GetMetadataString_ShouldFormatMetadata_Performance()
@@ -375,46 +259,6 @@ namespace PhotoLocator.Metadata
                 Assert.AreEqual("FC7303, 100.7m, 1/80s, f/2.8, 4.49mm, ISO100, 06/17/2022 19:03:02", str);
             }
             Console.WriteLine(sw.ElapsedMilliseconds);
-        }
-
-        [TestMethod]
-        public async Task TransferMetadataAsync_ShouldCopyMetadataToTargetFile()
-        {
-            if (!File.Exists(ExifToolPath))
-                Assert.Inconclusive("ExifTool not found");
-
-            const string MetadataFile = @"TestData\2022-06-17_19.03.02.jpg";
-            const string SourceFile = @"TestData\2025-05-04_15.13.08-04.jpg";
-            const string TargetFile = @"TestData\2025-05-04_15.13.08-04-metadata.jpg";
-            File.Delete(TargetFile);
-
-            await ExifHandler.TransferMetadataAsync(MetadataFile, SourceFile, TargetFile, ExifToolPath, CancellationToken.None);
-
-            var sourceMetadata = ExifHandler.LoadMetadataUsingExifTool(MetadataFile, ExifToolPath);
-            var targetMetadata = ExifHandler.LoadMetadataUsingExifTool(TargetFile, ExifToolPath);
-            Assert.AreEqual(sourceMetadata["Model"], targetMetadata["Model"]);
-            Assert.AreEqual(sourceMetadata["DateTimeOriginal"], targetMetadata["DateTimeOriginal"]);
-            Assert.AreEqual(sourceMetadata["ISO"], targetMetadata["ISO"]);
-        }
-
-        [TestMethod]
-        public async Task TransferMetadataAsync_ShouldWorkInPlace()
-        {
-            if (!File.Exists(ExifToolPath))
-                Assert.Inconclusive("ExifTool not found");
-
-            const string MetadataFile = @"TestData\2022-06-17_19.03.02.jpg";
-            const string SourceFile = @"TestData\2025-05-04_15.13.08-04.jpg";
-            const string TempFile = @"TestData\2025-05-04_15.13.08-04-inplace.jpg";
-            File.Copy(SourceFile, TempFile, true);
-
-            await ExifHandler.TransferMetadataAsync(MetadataFile, TempFile, TempFile, ExifToolPath, CancellationToken.None);
-
-            var sourceMetadata = ExifHandler.LoadMetadataUsingExifTool(MetadataFile, ExifToolPath);
-            var targetMetadata = ExifHandler.LoadMetadataUsingExifTool(TempFile, ExifToolPath);
-            Assert.AreEqual(sourceMetadata["Model"], targetMetadata["Model"]);
-            Assert.AreEqual(sourceMetadata["DateTimeOriginal"], targetMetadata["DateTimeOriginal"]);
-            Assert.AreEqual(sourceMetadata["ISO"], targetMetadata["ISO"]);
         }
     }
 }

--- a/PhotoLocatorTest/Metadata/ExifToolTest.cs
+++ b/PhotoLocatorTest/Metadata/ExifToolTest.cs
@@ -1,0 +1,164 @@
+using System.Globalization;
+
+namespace PhotoLocator.Metadata;
+
+[TestClass]
+public class ExifToolTest
+{
+    const string ExifToolPath = @"exiftool\exiftool(-m).exe";
+
+    [TestMethod]
+    public async Task AdjustTimestampAsync_ShouldUpdateTimestamp()
+    {
+        if (!File.Exists(ExifToolPath))
+            Assert.Inconclusive("ExifTool not found");
+
+        const string TargetFileName = @"TestData\2022-06-17_18.03.02.jpg";
+
+        await ExifTool.AdjustTimeStampAsync(@"TestData\2022-06-17_19.03.02.jpg", TargetFileName, "-01:00:00", ExifToolPath, default);
+
+        using var targetFile = File.OpenRead(TargetFileName);
+        var metadata = ExifHandler.LoadMetadata(targetFile);
+        var tag = ExifHandler.DecodeTimeStamp(metadata!, targetFile) ?? throw new FileFormatException("Failed to decode timestamp");
+        Assert.AreEqual(new DateTime(2022, 06, 17, 18, 03, 02, DateTimeKind.Local), tag);
+    }
+
+    [TestMethod]
+    public async Task TransferMetadataAsync_ShouldCopyMetadataToTargetFile()
+    {
+        if (!File.Exists(ExifToolPath))
+            Assert.Inconclusive("ExifTool not found");
+
+        const string MetadataFile = @"TestData\2022-06-17_19.03.02.jpg";
+        const string SourceFile = @"TestData\2025-05-04_15.13.08-04.jpg";
+        const string TargetFile = @"TestData\2025-05-04_15.13.08-04-metadata.jpg";
+        File.Delete(TargetFile);
+
+        await ExifTool.TransferMetadataAsync(MetadataFile, SourceFile, TargetFile, ExifToolPath, CancellationToken.None);
+
+        var sourceMetadata = ExifTool.LoadMetadata(MetadataFile, ExifToolPath);
+        var targetMetadata = ExifTool.LoadMetadata(TargetFile, ExifToolPath);
+        Assert.AreEqual(sourceMetadata["Model"], targetMetadata["Model"]);
+        Assert.AreEqual(sourceMetadata["DateTimeOriginal"], targetMetadata["DateTimeOriginal"]);
+        Assert.AreEqual(sourceMetadata["ISO"], targetMetadata["ISO"]);
+    }
+
+    [TestMethod]
+    public async Task TransferMetadataAsync_ShouldWorkInPlace()
+    {
+        if (!File.Exists(ExifToolPath))
+            Assert.Inconclusive("ExifTool not found");
+
+        const string MetadataFile = @"TestData\2022-06-17_19.03.02.jpg";
+        const string SourceFile = @"TestData\2025-05-04_15.13.08-04.jpg";
+        const string TempFile = @"TestData\2025-05-04_15.13.08-04-inplace.jpg";
+        File.Copy(SourceFile, TempFile, true);
+
+        await ExifTool.TransferMetadataAsync(MetadataFile, TempFile, TempFile, ExifToolPath, CancellationToken.None);
+
+        var sourceMetadata = ExifTool.LoadMetadata(MetadataFile, ExifToolPath);
+        var targetMetadata = ExifTool.LoadMetadata(TempFile, ExifToolPath);
+        Assert.AreEqual(sourceMetadata["Model"], targetMetadata["Model"]);
+        Assert.AreEqual(sourceMetadata["DateTimeOriginal"], targetMetadata["DateTimeOriginal"]);
+        Assert.AreEqual(sourceMetadata["ISO"], targetMetadata["ISO"]);
+    }
+
+    [TestMethod]
+    public async Task SetGeotag_ShouldSet_UsingBitmapMetadata()
+    {
+        var setValue = new MapControl.Location(-10, -20);
+        await ExifTool.SetGeotagAsync(@"TestData\2022-06-17_19.03.02.jpg", @"TestData\2022-06-17_19.03.02-out1.jpg", setValue, null, default);
+
+        var newValue = ExifHandler.GetGeotag(@"TestData\2022-06-17_19.03.02-out1.jpg");
+        Assert.AreEqual(setValue, newValue);
+    }
+
+    [TestMethod]
+    public async Task SetGeotag_ShouldSet_UsingExifTool()
+    {
+        if (!File.Exists(ExifToolPath))
+            Assert.Inconclusive("ExifTool not found");
+
+        var setValue = new MapControl.Location(-10, -20);
+        await ExifTool.SetGeotagAsync(@"TestData\2022-06-17_19.03.02.jpg", @"TestData\2022-06-17_19.03.02-out2.jpg", setValue, ExifToolPath, default);
+
+        var newValue = ExifHandler.GetGeotag(@"TestData\2022-06-17_19.03.02-out2.jpg");
+        Assert.AreEqual(setValue, newValue);
+    }
+
+    [TestMethod]
+    public async Task SetGeotag_ShouldSet_UsingExifTool_InPlace()
+    {
+        if (!File.Exists(ExifToolPath))
+            Assert.Inconclusive("ExifTool not found");
+
+        var setValue = new MapControl.Location(-10, -20);
+        File.Copy(@"TestData\2022-06-17_19.03.02.jpg", @"TestData\2022-06-17_19.03.02_copy.jpg", true);
+        await ExifTool.SetGeotagAsync(@"TestData\2022-06-17_19.03.02_copy.jpg", @"TestData\2022-06-17_19.03.02_copy.jpg", setValue, ExifToolPath, default);
+
+        var newValue = ExifHandler.GetGeotag(@"TestData\2022-06-17_19.03.02_copy.jpg");
+        Assert.AreEqual(setValue, newValue);
+    }
+
+    [TestMethod]
+    public async Task SetGeotag_ShouldSetInCr3_UsingExifTool()
+    {
+        const string FileName = @"TestData\Test.CR3";
+
+        if (!File.Exists(FileName))
+            Assert.Inconclusive("Image not found");
+        if (!File.Exists(ExifToolPath))
+            Assert.Inconclusive("ExifTool not found");
+
+        var setValue = new MapControl.Location(-10, -20);
+        await ExifTool.SetGeotagAsync(FileName, "tagged.cr3", setValue, ExifToolPath, default);
+
+        var newValue = ExifHandler.GetGeotag("tagged.cr3");
+        Assert.AreEqual(setValue, newValue);
+    }
+
+    [TestMethod]
+    public void DecodeMetadata_ShouldDecode()
+    {
+        if (!File.Exists(ExifToolPath))
+            Assert.Inconclusive("ExifTool not found");
+
+        Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+
+        var metadata = ExifTool.DecodeMetadata(@"TestData\2022-06-17_19.03.02.jpg", ExifToolPath);
+
+        Assert.AreEqual("FC7303, 1/80s, f/2.8, 4.5 mm, ISO100, 341x191, " + ExifHandlerTest.JpegTestDataTimestamp, metadata.Metadata);
+        Assert.AreEqual(new DateTimeOffset(2022, 6, 17, 19, 3, 2, TimeSpan.FromHours(2)), metadata.TimeStamp);
+        Assert.AreEqual(55.4, metadata.Location!.Latitude, 0.1);
+        Assert.AreEqual(11.2, metadata.Location!.Longitude, 0.1);
+    }
+
+    [TestMethod]
+    public void DecodeTimestamp_ShouldUseOffset()
+    {
+        var dict = new Dictionary<string, string>
+            {
+                { "DateTimeOriginal", "2025:02:01 22:14:54" },
+                { "OffsetTimeOriginal", "+01:00" }
+            };
+
+        var timestamp = ExifTool.DecodeTimeStamp(dict);
+
+        Assert.AreEqual(new DateTimeOffset(2025, 2, 1, 22, 14, 54, TimeSpan.FromHours(1)), timestamp);
+    }
+
+    [TestMethod]
+    [DataRow(@"TestData\Canon90DVideo.txt", 2024, 7, 9, 14, 38, 53, 0, +2)]
+    [DataRow(@"TestData\DJIAction2Video.txt", 2022, 4, 16, 18, 46, 28, 0, +2)]
+    [DataRow(@"TestData\iPhoneVideo.txt", 2022, 9, 23, 12, 50, 53, 0, +2)]
+    [DataRow(@"TestData\Mini2Video.txt", 2024, 7, 9, 13, 9, 22, 0, +2)]
+    [DataRow(@"TestData\Pixel5Video.txt", 2025, 4, 26, 17, 6, 45, 0, +2)]
+    public void DecodeTimestamp_ShouldHandleDifferentFormats(string fileName, int year, int month, int day, int hour, int minutes, int seconds, int ms, int offset)
+    {
+        var metadata = ExifTool.DecodeMetadataToDictionary(File.ReadAllLines(fileName));
+
+        var decoded = ExifTool.DecodeTimeStamp(metadata);
+
+        Assert.AreEqual(new DateTimeOffset(year, month, day, hour, minutes, seconds, ms, TimeSpan.FromHours(offset)), decoded);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to paste metadata from a copied file to the selected photo via a new context menu option.
  * Introduced keyboard shortcut (Shift+Insert) for pasting location data in the photo list.

* **Improvements**
  * Enhanced error handling and user feedback when ExifTool is not configured.
  * Refined keyboard input handling for photo selection and metadata operations.
  * Improved performance logging for image resampling.
  * Replaced internal metadata processing with a new external ExifTool integration for improved metadata handling.

* **Bug Fixes**
  * Improved validation of camera timezone offsets to prevent invalid values.

* **Tests**
  * Added tests to verify metadata transfer functionality, including both file-to-file and in-place updates.
  * Removed outdated tests related to previous internal ExifTool handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->