### PR TITLE
Support 16bit output from Local contrast&brightness

### DIFF
--- a/PhotoLocator/BitmapOperations/FloatBitmap.cs
+++ b/PhotoLocator/BitmapOperations/FloatBitmap.cs
@@ -225,6 +225,38 @@ namespace PhotoLocator.BitmapOperations
             }));
         }
 
+        public BitmapSource ToBitmapSource16(double dpiX, double dpiY, double gamma)
+        {
+            if (Elements is null)
+                throw new InvalidOperationException("Bitmap not initialized");
+
+            gamma = 1 / gamma;
+            var pixels = new ushort[Height * Stride];
+            unsafe
+            {
+                Parallel.For(0, Height, y =>
+                {
+                    var stride = Stride;
+                    fixed (float* srcRow = &Elements[y, 0])
+                    fixed (ushort* dstRow = &pixels[y * stride])
+                    {
+                        for (var x = 0; x < stride; x++)
+                            dstRow[x] = (ushort)(Math.Pow(float.Clamp(srcRow[x], 0, 1), gamma) * 0xffff + 0.5);
+                    }
+                });
+            }
+
+            PixelFormat pixelFormat16 = PlaneCount switch
+            {
+                1 => PixelFormats.Gray16,
+                3 => PixelFormats.Rgb48,
+                _ => throw new UserMessageException("Unsupported number of planes for 16 bit output: " + PlaneCount)
+            };
+            var result = BitmapSource.Create(Width, Height, dpiX, dpiY, pixelFormat16, null, pixels, Stride * 2);
+            result.Freeze();
+            return result;
+        }
+
         private byte[] ToPixels8(double gamma)
         {
             if (Elements is null)

--- a/PhotoLocator/ImageTransformCommands.cs
+++ b/PhotoLocator/ImageTransformCommands.cs
@@ -171,7 +171,7 @@ namespace PhotoLocator
                 var sameDir = Path.GetDirectoryName(selectedItem.FullPath) == Path.GetDirectoryName(dlg.FileName);
                 await Task.Run(() =>
                 {
-                    var resultImage = localContrastViewModel.GetResultImage(GeneralFileFormatHandler.Produce16bitOutputForFormat(dlg.FileName, _mainViewModel.Settings));
+                    var resultImage = localContrastViewModel.GetResultImage(GeneralFileFormatHandler.ShouldProduce16bitOutputForFormat(dlg.FileName, _mainViewModel.Settings));
                     GeneralFileFormatHandler.SaveToFile(resultImage, dlg.FileName, ExifHandler.ResetOrientation(metadata), _mainViewModel.Settings);
                 });
                 if (sameDir)

--- a/PhotoLocator/ImageTransformCommands.cs
+++ b/PhotoLocator/ImageTransformCommands.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
 namespace PhotoLocator
@@ -171,7 +172,9 @@ namespace PhotoLocator
                 var sameDir = Path.GetDirectoryName(selectedItem.FullPath) == Path.GetDirectoryName(dlg.FileName);
                 await Task.Run(() =>
                 {
-                    var resultImage = localContrastViewModel.GetResultImage(GeneralFileFormatHandler.ShouldProduce16bitOutputForFormat(dlg.FileName, _mainViewModel.Settings));
+                    var resultImage = localContrastViewModel.GetResultImage(
+                        localContrastViewModel.SourceBitmap?.Format != PixelFormats.Cmyk32 &&
+                        GeneralFileFormatHandler.ShouldProduce16bitOutputForFormat(dlg.FileName, _mainViewModel.Settings));
                     GeneralFileFormatHandler.SaveToFile(resultImage, dlg.FileName, ExifHandler.ResetOrientation(metadata), _mainViewModel.Settings);
                 });
                 if (sameDir)

--- a/PhotoLocator/ImageTransformCommands.cs
+++ b/PhotoLocator/ImageTransformCommands.cs
@@ -169,8 +169,11 @@ namespace PhotoLocator
             {
                 await using var pause = _mainViewModel.PauseFileSystemWatcher();
                 var sameDir = Path.GetDirectoryName(selectedItem.FullPath) == Path.GetDirectoryName(dlg.FileName);
-                await Task.Run(() => GeneralFileFormatHandler.SaveToFile(localContrastViewModel.PreviewPictureSource!, dlg.FileName,
-                    ExifHandler.ResetOrientation(metadata), _mainViewModel.Settings));
+                await Task.Run(() =>
+                {
+                    var resultImage = localContrastViewModel.GetResultImage(GeneralFileFormatHandler.Produce16bitOutputForFormat(dlg.FileName, _mainViewModel.Settings));
+                    GeneralFileFormatHandler.SaveToFile(resultImage, dlg.FileName, ExifHandler.ResetOrientation(metadata), _mainViewModel.Settings);
+                });
                 if (sameDir)
                     await _mainViewModel.AddOrUpdateItemAsync(dlg.FileName, false, false);
             }

--- a/PhotoLocator/LocalContrastViewModel.cs
+++ b/PhotoLocator/LocalContrastViewModel.cs
@@ -574,6 +574,16 @@ namespace PhotoLocator
             && DetailHandling == 1 && ToneMapping == 1 && HighlightStrength == 0 && ShadowStrength == 0 && Contrast == DefaultContrast
             && !_colorToneOperation.AreToneAdjustmentsChanged;
 
+        public BitmapSource GetResultImage(bool produce16bitOutput)
+        {
+            if (produce16bitOutput)
+            {
+                var srcBitmap = SourceBitmap ?? throw new InvalidOperationException("Source bitmap not set");
+                return _localContrastOperation.DstBitmap.ToBitmapSource16(srcBitmap.DpiX, srcBitmap.DpiY, FloatBitmap.DefaultMonitorGamma);
+            }
+            return PreviewPictureSource ?? throw new InvalidOperationException("Operation has not completed");
+        }
+
         public BitmapSource ApplyOperations(BitmapSource source)
         {
             if (IsNoOperation) 

--- a/PhotoLocator/LocalContrastViewModel.cs
+++ b/PhotoLocator/LocalContrastViewModel.cs
@@ -33,7 +33,19 @@ namespace PhotoLocator
             _updateTimer = new DispatcherTimer(
                 TimeSpan.FromMilliseconds(100),
                 DispatcherPriority.Background,
-                async (s, e) => await UpdatePreviewAsync(),
+                async (s, e) =>
+                {
+                    try
+                    {
+                        await UpdatePreviewAsync();
+                    }
+                    catch(Exception ex)
+                    {
+                        _previewTask = Task.CompletedTask;
+                        Mouse.OverrideCursor = null;
+                        ExceptionHandler.ShowException(ex);
+                    }
+                },
                 Application.Current.Dispatcher) { IsEnabled = false };
         }
 

--- a/PhotoLocator/PictureFileFormats/GeneralFileFormatHandler.cs
+++ b/PhotoLocator/PictureFileFormats/GeneralFileFormatHandler.cs
@@ -46,6 +46,12 @@ namespace PhotoLocator.PictureFileFormats
             return bitmap;
         }
 
+        public static bool Produce16bitOutputForFormat(string fileName, ISettings settings)
+        {
+            var format = Path.GetExtension(fileName).ToLowerInvariant();
+            return format is ".png" or ".tif" or ".tiff" or ".jxr" || format is ".jxl" && settings?.JpegQuality == 100;
+        }
+
         public static void SaveToFile(BitmapSource bitmap, string targetPath, BitmapMetadata? metadata = null, ISettings? settings = null)
         {
             var ext = Path.GetExtension(targetPath).ToLowerInvariant();

--- a/PhotoLocator/PictureFileFormats/GeneralFileFormatHandler.cs
+++ b/PhotoLocator/PictureFileFormats/GeneralFileFormatHandler.cs
@@ -46,7 +46,7 @@ namespace PhotoLocator.PictureFileFormats
             return bitmap;
         }
 
-        public static bool Produce16bitOutputForFormat(string fileName, ISettings settings)
+        public static bool ShouldProduce16bitOutputForFormat(string fileName, ISettings settings)
         {
             var format = Path.GetExtension(fileName).ToLowerInvariant();
             return format is ".png" or ".tif" or ".tiff" or ".jxr" || format is ".jxl" && settings?.JpegQuality == 100;

--- a/PhotoLocator/VideoTransformCommands.cs
+++ b/PhotoLocator/VideoTransformCommands.cs
@@ -1046,7 +1046,7 @@ public class VideoTransformCommands : INotifyPropertyChanged
         using var process = new AverageFramesOperation(DarkFramePath, ParseRegistrationSettings(), ct);
         await _videoTransforms.RunFFmpegWithStreamOutputImagesAsync($"{InputArguments} {ProcessArguments}", process.ProcessImage, ProcessStdError, ct).ConfigureAwait(false);
         GeneralFileFormatHandler.SaveToFile(
-            process.Supports16BitResult() && GeneralFileFormatHandler.Produce16bitOutputForFormat(outFileName, _mainViewModel.Settings) ? process.GetResult16() : process.GetResult8(),
+            process.Supports16BitResult() && GeneralFileFormatHandler.ShouldProduce16bitOutputForFormat(outFileName, _mainViewModel.Settings) ? process.GetResult16() : process.GetResult8(),
             outFileName, CreateImageMetadata(), _mainViewModel.Settings);
         return $"Processed {process.ProcessedImages} frames in {sw.Elapsed.TotalSeconds:N1}s";
     }

--- a/PhotoLocator/VideoTransformCommands.cs
+++ b/PhotoLocator/VideoTransformCommands.cs
@@ -1046,7 +1046,7 @@ public class VideoTransformCommands : INotifyPropertyChanged
         using var process = new AverageFramesOperation(DarkFramePath, ParseRegistrationSettings(), ct);
         await _videoTransforms.RunFFmpegWithStreamOutputImagesAsync($"{InputArguments} {ProcessArguments}", process.ProcessImage, ProcessStdError, ct).ConfigureAwait(false);
         GeneralFileFormatHandler.SaveToFile(
-            process.Supports16BitResult() && Path.GetExtension(outFileName).ToLowerInvariant() is ".png" or ".tif" or ".tiff" or ".jxr" or ".jxl" ? process.GetResult16() : process.GetResult8(), 
+            process.Supports16BitResult() && GeneralFileFormatHandler.Produce16bitOutputForFormat(outFileName, _mainViewModel.Settings) ? process.GetResult16() : process.GetResult8(),
             outFileName, CreateImageMetadata(), _mainViewModel.Settings);
         return $"Processed {process.ProcessedImages} frames in {sw.Elapsed.TotalSeconds:N1}s";
     }

--- a/PhotoLocatorTest/BitmapOperations/FloatBitmapTest.cs
+++ b/PhotoLocatorTest/BitmapOperations/FloatBitmapTest.cs
@@ -118,6 +118,31 @@ namespace PhotoLocator.BitmapOperations
         }
 
         [TestMethod]
+        [DataRow(6, 4, 1, 1, null)]
+        [DataRow(6, 4, 3, 1, null)]
+        public void ToBitmapSource16_ShouldCreateBitmapSource(int width, int height, int planes, int iterations, string? fileName)
+        {
+            var floatBitmap = new FloatBitmap(width, height, planes);
+            var scale = 1.0f / width;
+            floatBitmap.ProcessElementWise((x, y) => x * scale);
+            for (int i = 0; i < iterations; i++)
+            {
+                var sw = Stopwatch.StartNew();
+                var bitmap = floatBitmap.ToBitmapSource16(96, 96, FloatBitmap.DefaultMonitorGamma);
+                Console.WriteLine(sw.ElapsedMilliseconds);
+
+                Assert.AreEqual(width, bitmap.PixelWidth);
+                Assert.AreEqual(height, bitmap.PixelHeight);
+                if (planes == 1)
+                    Assert.AreEqual(PixelFormats.Gray16, bitmap.Format);
+                else if (planes == 3)
+                    Assert.AreEqual(PixelFormats.Rgb48, bitmap.Format);
+                if (fileName is not null)
+                    GeneralFileFormatHandler.SaveToFile(bitmap, fileName);
+            }
+        }
+
+        [TestMethod]
         public void MinMax_ShouldReturnMinMax()
         {
             var floatBitmap = new FloatBitmap(6, 4, 3);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conversion to 16-bit output for processed float bitmap data (16-bit grayscale and 16-bit RGB).
  * Output now automatically selects 16-bit for compatible formats (PNG, TIFF, JXR, and qualifying JPEG XL); applies to video averaging results as well.
  * Local contrast can now be saved at the appropriate bit depth.

* **Bug Fixes**
  * Saving processed images now uses the newly generated result image instead of the preview.
  * Improved local contrast preview robustness by handling update errors and reporting them.

* **Tests**
  * Added coverage for 16-bit bitmap source generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->