### PR TITLE
Support for saving and loading image adjustments

### DIFF
--- a/PhotoLocator/ImageTransformCommands.cs
+++ b/PhotoLocator/ImageTransformCommands.cs
@@ -106,7 +106,13 @@ namespace PhotoLocator
             using (var cursor = new MouseCursorOverride())
             {
                 (var image, metadata) = await Task.Run(() => LoadImageWithMetadataAsync(selectedItem));
-                localContrastViewModel = new LocalContrastViewModel() { IsAstroModeEnabled = o as string == AstroCommandParameter, SourceBitmap = image };
+                localContrastViewModel = new LocalContrastViewModel() 
+                { 
+                    IsAstroModeEnabled = o as string == AstroCommandParameter, 
+                    SourceBitmap = image,
+                    FileName = selectedItem.FullPath,
+                };
+                localContrastViewModel.TryLoadAdjustments();
             }
             var window = new LocalContrastView();
             window.Owner = Application.Current.MainWindow;

--- a/PhotoLocator/LocalContrastView.xaml
+++ b/PhotoLocator/LocalContrastView.xaml
@@ -21,6 +21,9 @@
     <Window.InputBindings>
         <KeyBinding Key="C" Modifiers="Ctrl+Shift" Command="{Binding CopyAdjustmentsCommand}" />
         <KeyBinding Key="V" Modifiers="Ctrl+Shift" Command="{Binding PasteAdjustmentsCommand}" />
+        <KeyBinding Key="R" Modifiers="Ctrl+Shift" Command="{Binding RestoreLastUsedValuesCommand}" />
+        <KeyBinding Key="S" Modifiers="Ctrl" Command="{Binding SaveAdjustmentsCommand}" />
+        <KeyBinding Key="O" Modifiers="Ctrl" Command="{Binding LoadAdjustmentsCommand}" />
         <KeyBinding Key="D1" Modifiers="Ctrl" Command="{Binding ZoomToFitCommand}" />
         <KeyBinding Key="D2" Modifiers="Ctrl" Command="{Binding Zoom100Command}" />
         <KeyBinding Key="D3" Modifiers="Ctrl" Command="{Binding Zoom200Command}" />
@@ -39,7 +42,9 @@
                     <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE77F;" FontSize="14" Foreground="Black" />
                 </MenuItem.Icon>
             </MenuItem>
-            <MenuItem Header="Restore last used values" Command="{Binding RestoreLastUsedValuesCommand}" />
+            <MenuItem Header="Save adjustments (Ctrl+S)" Command="{Binding SaveAdjustmentsCommand}" />
+            <MenuItem Header="Load adjustments (Ctrl+O)" Command="{Binding LoadAdjustmentsCommand}" />
+            <MenuItem Header="Restore last used values (Ctrl+Shift+R)" Command="{Binding RestoreLastUsedValuesCommand}" />
         </ContextMenu>
     </Window.ContextMenu>
 
@@ -262,7 +267,9 @@
                             <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE77F;" FontSize="14" Foreground="Black" />
                         </MenuItem.Icon>
                     </MenuItem>
-                    <MenuItem Header="Restore last used values" Command="{Binding RestoreLastUsedValuesCommand}" />
+                    <MenuItem Header="Save adjustments (Ctrl+S)" Command="{Binding SaveAdjustmentsCommand}" />
+                    <MenuItem Header="Load adjustments (Ctrl+O)" Command="{Binding LoadAdjustmentsCommand}" />
+                    <MenuItem Header="Restore last used values (Ctrl+Shift+R)" Command="{Binding RestoreLastUsedValuesCommand}" />
                 </ContextMenu>
             </Grid.ContextMenu>
         </Grid>

--- a/PhotoLocator/LocalContrastViewModel.cs
+++ b/PhotoLocator/LocalContrastViewModel.cs
@@ -1,8 +1,11 @@
-﻿using PhotoLocator.BitmapOperations;
+﻿using Microsoft.Win32;
+using PhotoLocator.BitmapOperations;
 using PhotoLocator.Helpers;
+using PhotoLocator.PictureFileFormats;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows;
@@ -19,8 +22,8 @@ namespace PhotoLocator
     {
         enum FirstParamChanged { Astro, LaplacianPyramid, LocalContrast, ColorTone, None }
 
-        static readonly List<double> _adjustmentClipboard = [];
-        static readonly List<double> _lastUsedValues = [];
+        static AdjustmentValues? _adjustmentClipboard;
+        static AdjustmentValues? _lastUsedValues;
         readonly DispatcherTimer _updateTimer;
         readonly LaplacianFilterOperation _laplacianFilterOperation = new();
         readonly IncreaseLocalContrastOperation _localContrastOperation = new() { DstBitmap = new() };
@@ -65,6 +68,8 @@ namespace PhotoLocator
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
             return true;
         }
+
+        public string FileName { get; set; } = string.Empty;
 
         public BitmapSource? SourceBitmap
         {
@@ -402,66 +407,112 @@ namespace PhotoLocator
             StartUpdateTimer(FirstParamChanged.ColorTone);
         });
 
-        public ICommand CopyAdjustmentsCommand => new RelayCommand(o => StoreAdjustmentValues(_adjustmentClipboard));
+        public ICommand CopyAdjustmentsCommand => new RelayCommand(o => _adjustmentClipboard = StoreAdjustmentValues());
 
-        public ICommand PasteAdjustmentsCommand => new RelayCommand(o => RestoreAdjustmentValues(_adjustmentClipboard), o => _adjustmentClipboard.Count > 0);
+        public ICommand PasteAdjustmentsCommand => new RelayCommand(o => RestoreAdjustmentValues(_adjustmentClipboard ?? throw new UserMessageException("No adjustments saved")), o => _adjustmentClipboard is not null);
 
-        public ICommand RestoreLastUsedValuesCommand => new RelayCommand(o => RestoreAdjustmentValues(_lastUsedValues), o => _lastUsedValues.Count > 0);
+        public ICommand RestoreLastUsedValuesCommand => new RelayCommand(o => RestoreAdjustmentValues(_lastUsedValues ?? throw new UserMessageException("No adjustments saved")), o => _lastUsedValues is not null);
+
+        public ICommand SaveAdjustmentsCommand => new RelayCommand(o =>
+        {
+            var dlg = new SaveFileDialog
+            {
+                Title = "Save adjustments",
+                Filter = "Adjustment values (*.pla)|*.pla",
+                DefaultExt = "pla",
+                FileName = FileName + ".pla"
+            };
+            if (dlg.ShowDialog() is true)
+                StoreAdjustmentValues().SaveToJsonFile(dlg.FileName);
+        });
+
+        public ICommand LoadAdjustmentsCommand => new RelayCommand(o =>
+        {
+            var dlg = new OpenFileDialog
+            {
+                Title = "Load adjustments",
+                Filter = "Adjustment values (*.pla)|*.pla"
+            };
+            if (dlg.ShowDialog() is true)
+                RestoreAdjustmentValues(AdjustmentValues.LoadFromJsonFile(dlg.FileName));
+        });
+
+        public void TryLoadAdjustments()
+        {
+            var adjustmentsFileName = FileName + ".pla";
+            if (File.Exists(adjustmentsFileName))
+                try
+                {
+                    RestoreAdjustmentValues(AdjustmentValues.LoadFromJsonFile(adjustmentsFileName));
+                }
+                catch (Exception ex)
+                {
+                    Log.Write($"Error loading adjustments from '{adjustmentsFileName}': {ex.Message}");
+                }
+        }
 
         public void SaveLastUsedValues()
         {
-            StoreAdjustmentValues(_lastUsedValues);
+            _lastUsedValues = StoreAdjustmentValues();
         }
 
-        private void StoreAdjustmentValues(List<double> valueStore)
+        private AdjustmentValues StoreAdjustmentValues()
         {
-            valueStore.Clear();
-            valueStore.Add(AstroStretch);
-            valueStore.Add(BackgroundRemovalSmooth);
-            valueStore.Add(BlackPoint);
-            valueStore.Add(HighlightStrength);
-            valueStore.Add(ShadowStrength);
-            valueStore.Add(OutlierReductionStrength);
-            valueStore.Add(Contrast);
-            valueStore.Add(ToneMapping);
-            valueStore.Add(DetailHandling);
-            valueStore.Add(MaxStretch);
-            valueStore.Add(ToneRotation);
-            for (int i = 0; i < _colorToneOperation.ToneAdjustments.Length; i++)
+            var av = new AdjustmentValues();
+            av.AstroStretch = AstroStretch;
+            av.BackgroundRemovalSmooth = BackgroundRemovalSmooth;
+            av.BlackPoint = BlackPoint;
+            av.HighlightStrength = HighlightStrength;
+            av.ShadowStrength = ShadowStrength;
+            av.OutlierReductionStrength = OutlierReductionStrength;
+            av.Contrast = Contrast;
+            av.ToneMapping = ToneMapping;
+            av.DetailHandling = DetailHandling;
+            av.MaxStretch = MaxStretch;
+            av.ToneRotation = ToneRotation;
+            if (_colorToneOperation.AreToneAdjustmentsChanged)
             {
-                valueStore.Add(_colorToneOperation.ToneAdjustments[i].AdjustHue);
-                valueStore.Add(_colorToneOperation.ToneAdjustments[i].AdjustSaturation);
-                valueStore.Add(_colorToneOperation.ToneAdjustments[i].AdjustIntensity);
-                valueStore.Add(_colorToneOperation.ToneAdjustments[i].HueUniformity);
+                av.ToneAdjustments = new ToneAdjustmentValues[_colorToneOperation.ToneAdjustments.Length];
+                for (int i = 0; i < av.ToneAdjustments.Length; i++)
+                {
+                    var src = _colorToneOperation.ToneAdjustments[i];
+                    var dst = av.ToneAdjustments[i] = new ToneAdjustmentValues();
+                    dst.AdjustHue = src.AdjustHue;
+                    dst.AdjustSaturation = src.AdjustSaturation;
+                    dst.AdjustIntensity = src.AdjustIntensity;
+                    dst.HueUniformity = src.HueUniformity;
+                }
             }
+            return av;
         }
 
-        private void RestoreAdjustmentValues(List<double> valueStore)
+        private void RestoreAdjustmentValues(AdjustmentValues av)
         {
-            int a = 0;
-            AstroStretch = valueStore[a++];
-            BackgroundRemovalSmooth = valueStore[a++];
-            BlackPoint = valueStore[a++];
-            HighlightStrength = valueStore[a++];
-            ShadowStrength = valueStore[a++];
-            OutlierReductionStrength = valueStore[a++];
-            Contrast = valueStore[a++];
-            ToneMapping = valueStore[a++];
-            DetailHandling = valueStore[a++];
-            MaxStretch = valueStore[a++];
-            ToneRotation = valueStore[a++];
-            for (int i = 0; i < _colorToneOperation.ToneAdjustments.Length; i++)
-            {
-                _colorToneOperation.ToneAdjustments[i].AdjustHue = (float)valueStore[a++];
-                _colorToneOperation.ToneAdjustments[i].AdjustSaturation = (float)valueStore[a++];
-                _colorToneOperation.ToneAdjustments[i].AdjustIntensity = (float)valueStore[a++];
-                _colorToneOperation.ToneAdjustments[i].HueUniformity = (float)valueStore[a++];
-            }
+            AstroStretch = av.AstroStretch;
+            BackgroundRemovalSmooth = av.BackgroundRemovalSmooth;
+            BlackPoint = av.BlackPoint;
+            HighlightStrength = av.HighlightStrength;
+            ShadowStrength = av.ShadowStrength;
+            OutlierReductionStrength = av.OutlierReductionStrength;
+            Contrast = av.Contrast;
+            ToneMapping = av.ToneMapping;
+            DetailHandling = av.DetailHandling;
+            MaxStretch = av.MaxStretch;
+            ToneRotation = av.ToneRotation;
+            if (_colorToneOperation.ToneAdjustments.Length != av.ToneAdjustments.Length)
+                _colorToneOperation.ResetToneAdjustments();
+            else
+                for (int i = 0; i < av.ToneAdjustments.Length; i++)
+                {
+                    var src = av.ToneAdjustments[i];
+                    _colorToneOperation.ToneAdjustments[i].AdjustHue = src?.AdjustHue ?? 0;
+                    _colorToneOperation.ToneAdjustments[i].AdjustSaturation = src?.AdjustSaturation ?? 1;
+                    _colorToneOperation.ToneAdjustments[i].AdjustIntensity = src?.AdjustIntensity ?? 1;
+                    _colorToneOperation.ToneAdjustments[i].HueUniformity = src?.HueUniformity ?? 0;
+                }
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(null));
             ActiveToneIndex = _colorToneOperation.AreToneAdjustmentsChanged ? 0 : ColorToneAdjustOperation.NumberOfTones;
             StartUpdateTimer(FirstParamChanged.ColorTone);
-            if (a != valueStore.Count)
-                throw new InvalidOperationException("Unexpected number of adjustments");
         }
 
         private void StartUpdateTimer(FirstParamChanged firstParamChanged)

--- a/PhotoLocator/LocalContrastViewModel.cs
+++ b/PhotoLocator/LocalContrastViewModel.cs
@@ -499,7 +499,7 @@ namespace PhotoLocator
             DetailHandling = av.DetailHandling;
             MaxStretch = av.MaxStretch;
             ToneRotation = av.ToneRotation;
-            if (_colorToneOperation.ToneAdjustments.Length != av.ToneAdjustments.Length)
+            if (_colorToneOperation.ToneAdjustments.Length != av.ToneAdjustments?.Length)
                 _colorToneOperation.ResetToneAdjustments();
             else
                 for (int i = 0; i < av.ToneAdjustments.Length; i++)

--- a/PhotoLocator/MainViewModel.cs
+++ b/PhotoLocator/MainViewModel.cs
@@ -825,8 +825,8 @@ namespace PhotoLocator
                     var sidecarFiles = allSelected[0].GetSidecarFiles().ToArray();
                     if (sidecarFiles.Length > 0)
                     {
-                        var folderLength = Path.GetDirectoryName(allSelected[0].FullPath)?.Length + 1 ?? 0;
-                        msg += "\nIncluding sidecar files:" + $"\n{string.Join("\n", sidecarFiles.Select(f => f[folderLength..]))}";
+                        var folder = Path.GetDirectoryName(allSelected[0].FullPath) ?? string.Empty;
+                        msg += "\nIncluding sidecar files:" + $"\n{string.Join("\n", sidecarFiles.Select(f => Path.GetRelativePath(folder, f)))}";
                     }
                 }
             }

--- a/PhotoLocator/MainViewModel.cs
+++ b/PhotoLocator/MainViewModel.cs
@@ -824,7 +824,10 @@ namespace PhotoLocator
                 {
                     var sidecarFiles = allSelected[0].GetSidecarFiles().ToArray();
                     if (sidecarFiles.Length > 0)
-                        msg += "\nIncluding sidecar files:" + $"\n{string.Join("\n", sidecarFiles.Select(f => Path.GetFileName(f)))}";
+                    {
+                        var folderLength = Path.GetDirectoryName(allSelected[0].FullPath)?.Length + 1 ?? 0;
+                        msg += "\nIncluding sidecar files:" + $"\n{string.Join("\n", sidecarFiles.Select(f => f[folderLength..]))}";
+                    }
                 }
             }
             else

--- a/PhotoLocator/MainViewModel.cs
+++ b/PhotoLocator/MainViewModel.cs
@@ -817,7 +817,7 @@ namespace PhotoLocator
             focusedItem = GetNearestUnchecked(focusedItem, allSelected);
 
             string msg;
-            if (allSelected.Length == 1)
+            if (allSelected.Length == 1 && allSelected[0].IsFile)
             {
                 msg = $"Delete '{allSelected[0].Name}'?";
                 if (Settings.IncludeSidecarFiles)

--- a/PhotoLocator/MainViewModel.cs
+++ b/PhotoLocator/MainViewModel.cs
@@ -664,8 +664,7 @@ namespace PhotoLocator
                 UpdatePushpins();
                 return;
             }
-            if (_sunAndMoonMapCenter is null)
-                _sunAndMoonMapCenter = MapCenter;
+            _sunAndMoonMapCenter ??= MapCenter;
 
             void AddLineSeg(double azimuth, Color color, string text)
             {
@@ -816,10 +815,21 @@ namespace PhotoLocator
             if (allSelected.Length == 0)
                 return;
             focusedItem = GetNearestUnchecked(focusedItem, allSelected);
-            if (MessageBox.Show(
-                (allSelected.Length == 1 ? $"Delete '{allSelected[0].Name}'?" : $"Delete {allSelected.Length} selected items?") +
-                (Settings.IncludeSidecarFiles ? "\nSidecar files will be included." : string.Empty),
-                "Confirm", MessageBoxButton.OKCancel, MessageBoxImage.Question) != MessageBoxResult.OK)
+
+            string msg;
+            if (allSelected.Length == 1)
+            {
+                msg = $"Delete '{allSelected[0].Name}'?";
+                if (Settings.IncludeSidecarFiles)
+                {
+                    var sidecarFiles = allSelected[0].GetSidecarFiles().ToArray();
+                    if (sidecarFiles.Length > 0)
+                        msg += "\nIncluding sidecar files:" + $"\n{string.Join("\n", sidecarFiles.Select(f => Path.GetFileName(f)))}";
+                }
+            }
+            else
+                msg = $"Delete {allSelected.Length} selected items?" + (Settings.IncludeSidecarFiles ? "\nSidecar files will be included." : string.Empty);
+            if (MessageBox.Show(msg, "Confirm", MessageBoxButton.OKCancel, MessageBoxImage.Question) != MessageBoxResult.OK)
                 return;
             var selectedIndex = Items.IndexOf(SelectedItem!);
             SelectedItem = null;

--- a/PhotoLocator/PictureFileFormats/AdjustmentValues.cs
+++ b/PhotoLocator/PictureFileFormats/AdjustmentValues.cs
@@ -24,7 +24,7 @@ namespace PhotoLocator.PictureFileFormats
         public double DetailHandling { get; set; }
         public double MaxStretch { get; set; }
         public double ToneRotation { get; set; }
-        public ToneAdjustmentValues[] ToneAdjustments { get; set; } = [];
+        public ToneAdjustmentValues[]? ToneAdjustments { get; set; }
 
         static JsonSerializerOptions? _saveOptions, _loadOptions;
 

--- a/PhotoLocator/PictureFileFormats/AdjustmentValues.cs
+++ b/PhotoLocator/PictureFileFormats/AdjustmentValues.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using System.Text.Json;
+
+namespace PhotoLocator.PictureFileFormats
+{
+    internal class ToneAdjustmentValues
+    {
+        public float AdjustHue { get; set; }
+        public float AdjustSaturation { get; set; } = 1f;
+        public float AdjustIntensity { get; set; } = 1f;
+        public float HueUniformity { get; set; }
+    }
+
+    internal class AdjustmentValues
+    {
+        public double AstroStretch { get; set; }
+        public double BackgroundRemovalSmooth { get; set; }
+        public double BlackPoint { get; set; }
+        public double HighlightStrength { get; set; }
+        public double ShadowStrength { get; set; }
+        public double OutlierReductionStrength { get; set; }
+        public double Contrast { get; set; }
+        public double ToneMapping { get; set; }
+        public double DetailHandling { get; set; }
+        public double MaxStretch { get; set; }
+        public double ToneRotation { get; set; }
+        public ToneAdjustmentValues[] ToneAdjustments { get; set; } = [];
+
+        static JsonSerializerOptions? _saveOptions, _loadOptions;
+
+        public void SaveToJsonFile(string path)
+        {
+            _saveOptions ??= new JsonSerializerOptions { WriteIndented = true };
+            var json = JsonSerializer.Serialize(this, _saveOptions);
+            File.WriteAllText(path, json);
+        }
+
+        public static AdjustmentValues LoadFromJsonFile(string path)
+        {
+            var json = File.ReadAllText(path);
+            _loadOptions ??= new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var av = JsonSerializer.Deserialize<AdjustmentValues>(json, _loadOptions);
+            return av ?? throw new FileFormatException("Failed to deserialize adjustment values");
+        }
+    }
+}

--- a/PhotoLocator/PictureItemViewModel.cs
+++ b/PhotoLocator/PictureItemViewModel.cs
@@ -422,11 +422,11 @@ namespace PhotoLocator
             FullPath = newFullPath;
         }
 
-        private IEnumerable<string> GetSidecarFiles()
+        public IEnumerable<string> GetSidecarFiles()
         {
             var folder = Path.GetDirectoryName(FullPath)!;
             return Directory.GetFiles(folder, Path.ChangeExtension(Name, "xmp")).Concat(
-                Directory.GetFiles(folder, Name + ".*", System.IO.SearchOption.AllDirectories));
+                Directory.GetFiles(folder, Name + ".*", System.IO.SearchOption.AllDirectories).Except([FullPath]));
         }
 
         internal void Renamed(string newFullPath)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added keyboard shortcuts and menu options to save, load, and restore local-contrast adjustments.
  - Adjustments can now be saved to and loaded from files.
  - Previously saved adjustments are automatically restored when available.
  - Copy and restore actions preserve optional color-tone settings.

- **Bug Fixes**
  - Improved handling when clipboard or previous adjustment settings are unavailable.
  - Delete confirmations now show clearer sidecar file paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->